### PR TITLE
chore: [SEC-7924] pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,7 @@ jobs:
         run: PUPPETEER_HEADLESS=true xvfb-run --server-args="-screen 0 1920x1080x24" yarn test
 
       - name: Check bundle sizes
-        uses: preactjs/compressed-size-action@v2
+        uses: preactjs/compressed-size-action@8518045ed95e94e971b83333085e1cb99aa18aa8 # v2
         with:
           install-script: "yarn install --frozen-lockfile"
           build-script: "build:all"

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v2
+        uses: ataylorme/eslint-annotate-action@5f4dc2e3af8d3c21b727edb597e5503510b1dc9c # v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1
         with:
           publish: yarn run release
         env:
@@ -38,7 +38,7 @@ jobs:
         run: NODE_OPTIONS='--max-old-space-size=4096' DISABLE_WORKER_INLINING=true yarn turbo run prepublish --filter=@rrweb/web-extension
 
       - name: Publish Chrome Extension
-        uses: mnao305/chrome-extension-upload@v5.0.0
+        uses: mnao305/chrome-extension-upload@4008e29e13c144d0f6725462cbd49b7c291b4928 # v5.0.0
         if: steps.changesets.outputs.published == 'true'
         with:
           extension-id: 'pdaldeopoccdhlkabbkcjmecmmoninhe'

--- a/.github/workflows/style-check.yml
+++ b/.github/workflows/style-check.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           name: eslint_report.json
       - name: Annotate Code Linting Results
-        uses: ataylorme/eslint-annotate-action@v2
+        uses: ataylorme/eslint-annotate-action@5f4dc2e3af8d3c21b727edb597e5503510b1dc9c # v2
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           report-json: 'eslint_report.json'
@@ -90,7 +90,7 @@ jobs:
       - name: Prettify Code
         run: yarn prettier --write '**/*.{ts,md}'
       - name: Commit Changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a # v4
         with:
           commit_message: Apply formatting changes
           branch: ${{ github.head_ref }}


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs to prevent supply chain attacks.

Addresses findings from the [`third-party-action-not-pinned-to-commit-sha`](https://github.com/launchdarkly/semgrep-rules/blob/main/github-actions/third-party-action-not-pinned-to-commit-sha.yml) Semgrep rule.

## Test plan

- [ ] Verify CI passes with pinned action SHAs
<!-- ld-jira-link -->
---
Related Jira issue: [SEC-7924: Unpinned GitHub Actions remediation](https://launchdarkly.atlassian.net/browse/SEC-7924)
<!-- end-ld-jira-link -->