### PR TITLE
Remove nested turbo from package build scripts

### DIFF
--- a/packages/all/package.json
+++ b/packages/all/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "check-types": "tsc -noEmit",

--- a/packages/packer/package.json
+++ b/packages/packer/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "check-types": "tsc -noEmit",

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-record/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
+++ b/packages/plugins/rrweb-plugin-canvas-webrtc-replay/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/plugins/rrweb-plugin-console-record/package.json
+++ b/packages/plugins/rrweb-plugin-console-record/package.json
@@ -27,7 +27,7 @@
     "dev": "vite build --watch",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/plugins/rrweb-plugin-console-replay/package.json
+++ b/packages/plugins/rrweb-plugin-console-replay/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/plugins/rrweb-plugin-sequential-id-record/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-record/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
+++ b/packages/plugins/rrweb-plugin-sequential-id-replay/package.json
@@ -25,7 +25,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build"
   },

--- a/packages/record/package.json
+++ b/packages/record/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "check-types": "tsc -noEmit",

--- a/packages/replay/package.json
+++ b/packages/replay/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "test": "vitest run",
     "test:watch": "vitest watch",
     "check-types": "tsc -noEmit",

--- a/packages/rrdom-nodejs/package.json
+++ b/packages/rrdom-nodejs/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-alpha.18",
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "test": "vitest run",
     "test:watch": "vitest watch",

--- a/packages/rrdom/package.json
+++ b/packages/rrdom/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -12,7 +12,7 @@
     "test:update": "yarn build && vitest run --update",
     "bench": "vite build && vitest bench",
     "dev": "vite build --watch",
-    "build": "yarn turbo prepublish -F @highlight-run/rrweb-snapshot",
+    "build": "yarn check-types && vite build",
     "check-types": "tsc --noEmit",
     "prepublish": "yarn check-types && vite build",
     "lint": "yarn eslint src"

--- a/packages/rrweb/package.json
+++ b/packages/rrweb/package.json
@@ -17,7 +17,7 @@
     "repl": "yarn build && node scripts/repl.js",
     "live-stream": "yarn build && node scripts/stream.js",
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "tsc -noEmit && vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "tsc -noEmit && vite build",
     "lint": "yarn eslint src",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "dev": "vite build --watch",
-    "build": "yarn turbo run prepublish",
+    "build": "vite build",
     "check-types": "tsc -noEmit",
     "prepublish": "vite build",
     "lint": "yarn eslint src/**/*.ts"


### PR DESCRIPTION
## Summary
- Replace `\"build\": \"yarn turbo run prepublish\"` in each package with the command the nested turbo was going to run (e.g. `tsc -noEmit && vite build`), matching the existing pattern in `packages/utils`.
- The outer turbo invocation (e.g. `turbo run build` from a consumer repo) already walks the dep graph via `^build`, so the nested layer was redundant — all it did was re-enter turbo from inside a workspace already being scheduled.

## Why
On Linux, `yarn build` of a consumer project that depends on these packages (we hit this in [launchdarkly/observability-sdk](https://github.com/launchdarkly/observability-sdk)) would hang indefinitely with no subprocess activity. Every turbo process stuck in `futex_wait_queue`. No `vite`, no `tsc` ever spawned.

Root cause: each nested `yarn turbo run prepublish` re-runs turbo's root discovery from the package's own CWD, finds `rrweb/package.json` (with `workspaces`), and computes a repo-root hash **different from the outer turbo's root hash**. That means it tries to start its own turbo daemon — separate inotify instance, separate Unix socket under `/tmp/turbod/<hash>/`. When 10+ rrweb packages build in parallel, several nested turbos race to create the same daemon. On Linux, losing that race leaves you with a half-open socket connection to a daemon that's already been replaced, and you sit in `futex_wait` forever. macOS rarely hits this because `kqueue`/`fsevents` and BSD socket semantics resolve the race faster.

Observed symptom when stuck:

```
/tmp/turbod/
├── 2948c6004e604b3c/  # rrweb-snapshot CWD
├── 8be077b6d3282621/  # rrdom CWD
├── 973b7cc49da23c74/  # outer turbo root
└── e9931d89ef6fbc99/  # types CWD
```

Four daemons for one build = four root hashes = turbo thinks each package is its own root.

Additionally, most of these scripts were `yarn turbo run prepublish` **without** a `-F` filter, so each nested turbo tried to schedule `prepublish` across the entire rrweb workspace again — a graph the outer turbo had already walked.

## After
Only one turbo daemon exists (the one the outer run starts). `yarn build:sdk` in `observability-sdk` goes from \"stuck, need to cancel and retry 3× on Linux\" to ~58s deterministic.

Semantics are preserved: each new `build` script is the verbatim body of the same package's `prepublish` script. `prepublish` is left in place since it's a yarn/npm publish lifecycle name.

## Test plan
- [x] `yarn build` in `observability-sdk` on Linux — completes cleanly (18/18 tasks, no hang)
- [ ] Verify CI still passes here
- [ ] macOS sanity check (should be unaffected since it already completed; just faster now because of one fewer layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)