### PR TITLE
fix: restore ES2017 lib in tsconfig.base.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,7 +10,7 @@
     "moduleResolution": "Node",
     "rootDir": "src",
     "outDir": "dist",
-    "lib": ["es6", "dom"],
+    "lib": ["ES2017", "dom"],
     "sourceMap": true,
     "skipLibCheck": true,
     "declaration": true,


### PR DESCRIPTION
The upstream refresh (#29) took upstream's `"lib": ["es6", "dom"]` in `tsconfig.base.json`. That setting only compiles by accident in this repo standalone: vitest's type declarations pull in modern ES lib references, masking the source's uses of `Array.prototype.includes` (ES2016) and `Object.entries` (ES2017). Inside the observability-sdk workspace the type layout differs and `@highlight-run/rrweb`'s `tsc -noEmit` fails with TS2550 errors, breaking o11y's `build:sdk`.

Restores the fork's previous `ES2017` lib, which matches the APIs the source actually uses. `lib` only affects type-checking — emitted output is governed by `target`/vite config, so no runtime change.

Validated: standalone `tsc -noEmit` green for rrweb + rrweb-snapshot; observability-sdk `build:sdk` goes 9/11 failed → 18/18 green with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)