### PR TITLE
feat(replay): optional origin-isolated embedded replayer over postMessage

### DIFF
--- a/.changeset/origin-isolated-embedded-replayer.md
+++ b/.changeset/origin-isolated-embedded-replayer.md
@@ -1,0 +1,13 @@
+---
+"rrweb": minor
+---
+
+Add origin-isolated embedded replay (SEC-8885). New `EmbeddedReplayerHost` /
+`startEmbeddedReplayerHost` run the `Replayer` inside a sandboxed, cookieless,
+cross-origin iframe; `EmbeddedReplayerClient` drives it from the parent over a
+typed, origin-authenticated `postMessage` bridge that only ever transfers data
+(never functions/DOM, never `eval`). `buildHostDocument` emits the sandbox HTML
+shell with a `<meta>` CSP whose `script-src` omits `unsafe-eval`. This relocates
+all untrusted replay-data handling (including the canvas-argument deserializer)
+out of the embedding app's privileged origin. Purely additive; existing
+in-parent `Replayer` usage is unchanged.

--- a/.changeset/origin-isolated-embedded-replayer.md
+++ b/.changeset/origin-isolated-embedded-replayer.md
@@ -9,6 +9,10 @@ the parent page over a typed, origin-authenticated `postMessage` bridge that
 only ever transfers plain data (never functions or DOM nodes).
 `buildHostDocument` emits the HTML shell for that iframe, including a `<meta>`
 CSP that names only the host bundle in `script-src` and omits `unsafe-eval`.
+Because the replay wrapper is not reachable from the embedding page, the client
+also carries layout: `setLayout(scale, anchor)` sends scaling intent for the host
+to apply (retained across re-inits), and the host reports the rendered geometry
+back, which `getDimensions()` exposes and a `dimensions` event announces.
 Embedders who adopt this run replay outside their own origin, so the replay path
 has no app cookies, no same-origin access to app APIs, and no reach into the
 embedding page. Opt-in and purely additive: existing in-parent `Replayer` usage

--- a/.changeset/origin-isolated-embedded-replayer.md
+++ b/.changeset/origin-isolated-embedded-replayer.md
@@ -2,12 +2,14 @@
 "rrweb": minor
 ---
 
-Add origin-isolated embedded replay (SEC-8885). New `EmbeddedReplayerHost` /
-`startEmbeddedReplayerHost` run the `Replayer` inside a sandboxed, cookieless,
-cross-origin iframe; `EmbeddedReplayerClient` drives it from the parent over a
-typed, origin-authenticated `postMessage` bridge that only ever transfers data
-(never functions/DOM, never `eval`). `buildHostDocument` emits the sandbox HTML
-shell with a `<meta>` CSP whose `script-src` omits `unsafe-eval`. This relocates
-all untrusted replay-data handling (including the canvas-argument deserializer)
-out of the embedding app's privileged origin. Purely additive; existing
-in-parent `Replayer` usage is unchanged.
+Add optional origin-isolated embedded replay. New `EmbeddedReplayerHost` /
+`startEmbeddedReplayerHost` run the `Replayer` inside a sandboxed iframe served
+from a separate, cross-site origin, and `EmbeddedReplayerClient` drives it from
+the parent page over a typed, origin-authenticated `postMessage` bridge that
+only ever transfers plain data (never functions or DOM nodes).
+`buildHostDocument` emits the HTML shell for that iframe, including a `<meta>`
+CSP that names only the host bundle in `script-src` and omits `unsafe-eval`.
+Embedders who adopt this run replay outside their own origin, so the replay path
+has no app cookies, no same-origin access to app APIs, and no reach into the
+embedding page. Opt-in and purely additive: existing in-parent `Replayer` usage
+is unchanged.

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -37,6 +37,8 @@ export {
   type EmbeddedReplayerClientOptions,
   type HostDocumentOptions,
   type SerializableReplayerConfig,
+  type ReplayAnchor,
+  type ReplayDimensions,
   type HostCommand,
   type HostMessage,
 } from './replay/embedded';

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -22,8 +22,9 @@ import './replay/styles/style.css';
 
 export type { recordOptions, ReplayPlugin } from './types';
 
-// Origin-isolated replay: run the Replayer inside a cookieless, cross-origin
-// iframe and drive it over postMessage (SEC-8885). See ./replay/embedded.
+// Optional origin-isolated replay: run the Replayer inside a sandboxed iframe
+// on a separate, cross-site origin and drive it over postMessage.
+// See ./replay/embedded.
 export {
   EmbeddedReplayerHost,
   startEmbeddedReplayerHost,

--- a/packages/rrweb/src/index.ts
+++ b/packages/rrweb/src/index.ts
@@ -22,6 +22,24 @@ import './replay/styles/style.css';
 
 export type { recordOptions, ReplayPlugin } from './types';
 
+// Origin-isolated replay: run the Replayer inside a cookieless, cross-origin
+// iframe and drive it over postMessage (SEC-8885). See ./replay/embedded.
+export {
+  EmbeddedReplayerHost,
+  startEmbeddedReplayerHost,
+  EmbeddedReplayerClient,
+  buildHostDocument,
+  pickSerializableConfig,
+  RRWEB_EMBEDDED_CHANNEL,
+  RRWEB_EMBEDDED_PROTOCOL_VERSION,
+  type EmbeddedReplayerHostOptions,
+  type EmbeddedReplayerClientOptions,
+  type HostDocumentOptions,
+  type SerializableReplayerConfig,
+  type HostCommand,
+  type HostMessage,
+} from './replay/embedded';
+
 const { addCustomEvent } = record;
 const { freezePage } = record;
 const { takeFullSnapshot } = record;

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -61,6 +61,14 @@ export class EmbeddedReplayerClient {
   private ready = false;
   private readyResolvers: Array<() => void> = [];
   private disposed = false;
+  /**
+   * Commands issued before the host handshakes. A command posted while the
+   * iframe is still on its initial `about:blank` (which carries the PARENT's
+   * origin) is rejected by the browser as an origin mismatch and lost — the
+   * viewer calls `setLayout` on mount, well before the host boots. Buffer until
+   * `ready`, then flush; by then the frame is on the host origin.
+   */
+  private pending: HostCommand[] = [];
 
   constructor(
     iframe: HTMLIFrameElement,
@@ -199,9 +207,25 @@ export class EmbeddedReplayerClient {
   /* --- internals -------------------------------------------------------- */
 
   private send(command: HostCommand): void {
+    // Hold commands until the host is ready (see `pending`), so they aren't
+    // posted at the host origin while the frame is still on about:blank.
+    if (!this.ready) {
+      this.pending.push(command);
+      return;
+    }
+    this.postToHost(command);
+  }
+
+  private postToHost(command: HostCommand): void {
     const target = this.iframe.contentWindow;
     if (!target) return;
     target.postMessage(wrap(command), this.hostOrigin);
+  }
+
+  private flushPending(): void {
+    const queued = this.pending;
+    this.pending = [];
+    queued.forEach((command) => this.postToHost(command));
   }
 
   /** Data-free handshake probe; see the note in the constructor. */
@@ -219,6 +243,7 @@ export class EmbeddedReplayerClient {
     switch (message.type) {
       case 'ready':
         this.ready = true;
+        this.flushPending(); // deliver commands buffered before the handshake
         this.readyResolvers.forEach((r) => r());
         this.readyResolvers = [];
         return;

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -8,9 +8,9 @@
  * the replay document.
  *
  * Peer authentication: the client identifies host messages by `event.source`
- * identity against the iframe's `contentWindow`. A sandboxed opaque-origin
- * iframe reports `event.origin === "null"`, so origin-string matching is not
- * usable here — source identity is the reliable check.
+ * identity against the iframe's `contentWindow`. Source identity holds no
+ * matter what origin the host document ends up on (it even survives the frame
+ * navigating), so it is the robust check on this side of the boundary.
  */
 
 import {
@@ -28,11 +28,11 @@ import type {
 
 export interface EmbeddedReplayerClientOptions {
   /**
-   * Target origin used when posting to the iframe. For a sandboxed
-   * opaque-origin host this must be "*" (an opaque frame's origin is "null",
-   * which cannot be named as a targetOrigin). Only replay data — never app
-   * secrets — is ever posted, so "*" is acceptable. When the host is served
-   * from a dedicated named origin, pass that origin for a tighter target.
+   * Target origin used when posting to the iframe. Pass the dedicated host
+   * origin (e.g. the origin `buildHostDocument`'s shell is served from) so
+   * replay data can only be delivered to the document it is meant for. The
+   * default is "*", which works before the host origin is known; only replay
+   * data — never app secrets — is ever posted over this channel.
    */
   hostOrigin?: string;
 }
@@ -59,6 +59,11 @@ export class EmbeddedReplayerClient {
     this.iframe = iframe;
     this.hostOrigin = options.hostOrigin ?? '*';
     window.addEventListener('message', this.onMessage);
+    // If the host booted before this client attached (e.g. a client re-created
+    // on a long-lived iframe), its one-shot `ready` announcement is gone —
+    // probe so it re-announces. Harmless when the iframe hasn't loaded yet:
+    // the message is dropped and the host's own boot-time `ready` arrives.
+    this.send({ type: 'ping' });
   }
 
   /** Resolves once the host iframe has loaded and announced readiness. */

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -1,0 +1,217 @@
+/**
+ * `EmbeddedReplayerClient` — runs in the PARENT page and drives an
+ * `EmbeddedReplayerHost` living in an isolated iframe, over `postMessage`.
+ *
+ * It mirrors the subset of the `Replayer` API the viewer actually needs
+ * (playback control + an `on(...)` event surface + async getters), so callers
+ * can treat it much like a local `Replayer` without any same-origin access to
+ * the replay document.
+ *
+ * Peer authentication: the client identifies host messages by `event.source`
+ * identity against the iframe's `contentWindow`. A sandboxed opaque-origin
+ * iframe reports `event.origin === "null"`, so origin-string matching is not
+ * usable here — source identity is the reliable check.
+ */
+
+import {
+  isEnvelope,
+  wrap,
+  type HostCommand,
+  type HostMessage,
+  type HostRequestMethod,
+  type PlayerMetaDataLike,
+  type SerializableReplayerConfig,
+} from './protocol';
+import type { eventWithTime } from '@rrweb/types';
+
+export interface EmbeddedReplayerClientOptions {
+  /**
+   * Target origin used when posting to the iframe. For a sandboxed
+   * opaque-origin host this must be "*" (an opaque frame's origin is "null",
+   * which cannot be named as a targetOrigin). Only replay data — never app
+   * secrets — is ever posted, so "*" is acceptable. When the host is served
+   * from a dedicated named origin, pass that origin for a tighter target.
+   */
+  hostOrigin?: string;
+}
+
+type Listener = (payload?: unknown) => void;
+
+export class EmbeddedReplayerClient {
+  private readonly iframe: HTMLIFrameElement;
+  private readonly hostOrigin: string;
+
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private readonly pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private nextRequestId = 1;
+
+  private metadata: PlayerMetaDataLike | null = null;
+  private lastCurrentTime = 0;
+  private ready = false;
+  private readyResolvers: Array<() => void> = [];
+  private disposed = false;
+
+  constructor(iframe: HTMLIFrameElement, options: EmbeddedReplayerClientOptions = {}) {
+    this.iframe = iframe;
+    this.hostOrigin = options.hostOrigin ?? '*';
+    window.addEventListener('message', this.onMessage);
+  }
+
+  /** Resolves once the host iframe has loaded and announced readiness. */
+  whenReady(): Promise<void> {
+    if (this.ready) return Promise.resolve();
+    return new Promise((resolve) => this.readyResolvers.push(resolve));
+  }
+
+  /* --- commands --------------------------------------------------------- */
+
+  init(
+    events: eventWithTime[],
+    config?: SerializableReplayerConfig,
+    autoplay = false,
+  ): void {
+    this.send({ type: 'init', events, config, autoplay });
+  }
+
+  play(timeOffset?: number): void {
+    this.send({ type: 'play', timeOffset });
+  }
+
+  pause(timeOffset?: number): void {
+    this.send({ type: 'pause', timeOffset });
+  }
+
+  resume(timeOffset?: number): void {
+    this.send({ type: 'resume', timeOffset });
+  }
+
+  setConfig(config: SerializableReplayerConfig): void {
+    this.send({ type: 'setConfig', config });
+  }
+
+  replaceEvents(events: eventWithTime[]): void {
+    this.send({ type: 'replaceEvents', events });
+  }
+
+  addEvent(event: eventWithTime): void {
+    this.send({ type: 'addEvent', event });
+  }
+
+  enableInteract(): void {
+    this.send({ type: 'enableInteract' });
+  }
+
+  disableInteract(): void {
+    this.send({ type: 'disableInteract' });
+  }
+
+  /** Tear down: destroys the host replayer and detaches the listener. */
+  destroy(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    try {
+      this.send({ type: 'destroy' });
+    } finally {
+      window.removeEventListener('message', this.onMessage);
+      this.listeners.clear();
+      this.pending.forEach((p) => p.reject(new Error('client destroyed')));
+      this.pending.clear();
+    }
+  }
+
+  /* --- event surface ---------------------------------------------------- */
+
+  on(event: string, listener: Listener): void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(listener);
+  }
+
+  off(event: string, listener: Listener): void {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  /* --- getters ---------------------------------------------------------- */
+
+  /** Best-effort last-known current time (pushed by the host while playing). */
+  getCurrentTime(): number {
+    return this.lastCurrentTime;
+  }
+
+  getMetaData(): Promise<PlayerMetaDataLike> {
+    if (this.metadata) return Promise.resolve(this.metadata);
+    return this.request('getMetaData') as Promise<PlayerMetaDataLike>;
+  }
+
+  getActivityIntervals(): Promise<unknown> {
+    return this.request('getActivityIntervals');
+  }
+
+  requestCurrentTime(): Promise<number> {
+    return this.request('getCurrentTime') as Promise<number>;
+  }
+
+  /* --- internals -------------------------------------------------------- */
+
+  private request(method: HostRequestMethod): Promise<unknown> {
+    const id = this.nextRequestId++;
+    return new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.send({ type: 'request', id, method });
+    });
+  }
+
+  private send(command: HostCommand): void {
+    const target = this.iframe.contentWindow;
+    if (!target) return;
+    target.postMessage(wrap(command), this.hostOrigin);
+  }
+
+  private onMessage = (event: MessageEvent): void => {
+    if (event.source !== this.iframe.contentWindow) return;
+    if (!isEnvelope<HostMessage>(event.data)) return;
+    this.handle(event.data.message);
+  };
+
+  private handle(message: HostMessage): void {
+    switch (message.type) {
+      case 'ready':
+        this.ready = true;
+        this.readyResolvers.forEach((r) => r());
+        this.readyResolvers = [];
+        return;
+      case 'initialized':
+        this.metadata = message.metadata;
+        this.emit('initialized', message.metadata);
+        return;
+      case 'replayer-event':
+        this.emit(message.event, message.payload);
+        return;
+      case 'time':
+        this.lastCurrentTime = message.currentTime;
+        this.emit('time', message.currentTime);
+        return;
+      case 'response': {
+        const pending = this.pending.get(message.id);
+        if (!pending) return;
+        this.pending.delete(message.id);
+        if (message.ok) pending.resolve(message.data);
+        else pending.reject(new Error(message.error));
+        return;
+      }
+      case 'error':
+        this.emit('error', message.message);
+        return;
+    }
+  }
+
+  private emit(event: string, payload?: unknown): void {
+    this.listeners.get(event)?.forEach((listener) => listener(payload));
+  }
+}

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -18,6 +18,7 @@ import {
   wrap,
   type HostCommand,
   type HostMessage,
+  type ReplayAnchor,
   type SerializableReplayerConfig,
 } from './protocol';
 import type {
@@ -39,6 +40,14 @@ export interface EmbeddedReplayerClientOptions {
 
 type Listener = (payload?: unknown) => void;
 
+/** Rendered geometry of the replay wrapper, as measured in the host realm. */
+export interface ReplayDimensions {
+  width: number;
+  height: number;
+  top: number;
+  left: number;
+}
+
 export class EmbeddedReplayerClient {
   private readonly iframe: HTMLIFrameElement;
   private readonly hostOrigin: string;
@@ -47,6 +56,7 @@ export class EmbeddedReplayerClient {
 
   private metadata: playerMetaData | null = null;
   private activityIntervals: SessionInterval[] = [];
+  private dimensions: ReplayDimensions | null = null;
   private lastCurrentTime = 0;
   private ready = false;
   private readyResolvers: Array<() => void> = [];
@@ -103,6 +113,16 @@ export class EmbeddedReplayerClient {
 
   setConfig(config: SerializableReplayerConfig): void {
     this.send({ type: 'setConfig', config });
+  }
+
+  /**
+   * Scale and position the replay. Compute `scale` from your own container size
+   * and the recorded viewport, as you would when driving a local `Replayer`;
+   * the host applies it, since the wrapper element is not reachable from here.
+   * The layout is retained across re-inits.
+   */
+  setLayout(scale: number, anchor?: ReplayAnchor): void {
+    this.send({ type: 'setLayout', scale, anchor });
   }
 
   replaceEvents(events: eventWithTime[]): void {
@@ -167,6 +187,15 @@ export class EmbeddedReplayerClient {
     return this.activityIntervals;
   }
 
+  /**
+   * Rendered geometry of the replay, in the host document's coordinate space —
+   * the cross-origin stand-in for `replayer.wrapper.getBoundingClientRect()`.
+   * Null until the host has reported it (listen for `'dimensions'`).
+   */
+  getDimensions(): ReplayDimensions | null {
+    return this.dimensions;
+  }
+
   /* --- internals -------------------------------------------------------- */
 
   private send(command: HostCommand): void {
@@ -204,6 +233,15 @@ export class EmbeddedReplayerClient {
       case 'time':
         this.lastCurrentTime = message.currentTime;
         this.emit('time', message.currentTime);
+        return;
+      case 'dimensions':
+        this.dimensions = {
+          width: message.width,
+          height: message.height,
+          top: message.top,
+          left: message.left,
+        };
+        this.emit('dimensions', this.dimensions);
         return;
       case 'error':
         this.emit('error', message.message);

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -52,7 +52,10 @@ export class EmbeddedReplayerClient {
   private readyResolvers: Array<() => void> = [];
   private disposed = false;
 
-  constructor(iframe: HTMLIFrameElement, options: EmbeddedReplayerClientOptions = {}) {
+  constructor(
+    iframe: HTMLIFrameElement,
+    options: EmbeddedReplayerClientOptions = {},
+  ) {
     this.iframe = iframe;
     this.hostOrigin = options.hostOrigin ?? '*';
     window.addEventListener('message', this.onMessage);

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -3,7 +3,7 @@
  * `EmbeddedReplayerHost` living in an isolated iframe, over `postMessage`.
  *
  * It mirrors the subset of the `Replayer` API the viewer actually needs
- * (playback control + an `on(...)` event surface + async getters), so callers
+ * (playback control + an `on(...)` event surface + cached getters), so callers
  * can treat it much like a local `Replayer` without any same-origin access to
  * the replay document.
  *
@@ -18,11 +18,13 @@ import {
   wrap,
   type HostCommand,
   type HostMessage,
-  type HostRequestMethod,
-  type PlayerMetaDataLike,
   type SerializableReplayerConfig,
 } from './protocol';
-import type { eventWithTime } from '@rrweb/types';
+import type {
+  eventWithTime,
+  playerMetaData,
+  SessionInterval,
+} from '@rrweb/types';
 
 export interface EmbeddedReplayerClientOptions {
   /**
@@ -42,13 +44,9 @@ export class EmbeddedReplayerClient {
   private readonly hostOrigin: string;
 
   private readonly listeners = new Map<string, Set<Listener>>();
-  private readonly pending = new Map<
-    number,
-    { resolve: (v: unknown) => void; reject: (e: Error) => void }
-  >();
-  private nextRequestId = 1;
 
-  private metadata: PlayerMetaDataLike | null = null;
+  private metadata: playerMetaData | null = null;
+  private activityIntervals: SessionInterval[] = [];
   private lastCurrentTime = 0;
   private ready = false;
   private readyResolvers: Array<() => void> = [];
@@ -117,8 +115,6 @@ export class EmbeddedReplayerClient {
     } finally {
       window.removeEventListener('message', this.onMessage);
       this.listeners.clear();
-      this.pending.forEach((p) => p.reject(new Error('client destroyed')));
-      this.pending.clear();
     }
   }
 
@@ -139,33 +135,24 @@ export class EmbeddedReplayerClient {
 
   /* --- getters ---------------------------------------------------------- */
 
-  /** Best-effort last-known current time (pushed by the host while playing). */
+  // Cached getters mirroring the local Replayer's synchronous ones. Metadata
+  // and activity intervals arrive on `initialized` (re-sent on replaceEvents);
+  // current time is streamed by the host while playing.
+
+  /** Last-known current time (pushed by the host while playing). */
   getCurrentTime(): number {
     return this.lastCurrentTime;
   }
 
-  getMetaData(): Promise<PlayerMetaDataLike> {
-    if (this.metadata) return Promise.resolve(this.metadata);
-    return this.request('getMetaData') as Promise<PlayerMetaDataLike>;
+  getMetaData(): playerMetaData | null {
+    return this.metadata;
   }
 
-  getActivityIntervals(): Promise<unknown> {
-    return this.request('getActivityIntervals');
-  }
-
-  requestCurrentTime(): Promise<number> {
-    return this.request('getCurrentTime') as Promise<number>;
+  getActivityIntervals(): SessionInterval[] {
+    return this.activityIntervals;
   }
 
   /* --- internals -------------------------------------------------------- */
-
-  private request(method: HostRequestMethod): Promise<unknown> {
-    const id = this.nextRequestId++;
-    return new Promise<unknown>((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.send({ type: 'request', id, method });
-    });
-  }
 
   private send(command: HostCommand): void {
     const target = this.iframe.contentWindow;
@@ -188,6 +175,7 @@ export class EmbeddedReplayerClient {
         return;
       case 'initialized':
         this.metadata = message.metadata;
+        this.activityIntervals = message.activityIntervals;
         this.emit('initialized', message.metadata);
         return;
       case 'replayer-event':
@@ -197,14 +185,6 @@ export class EmbeddedReplayerClient {
         this.lastCurrentTime = message.currentTime;
         this.emit('time', message.currentTime);
         return;
-      case 'response': {
-        const pending = this.pending.get(message.id);
-        if (!pending) return;
-        this.pending.delete(message.id);
-        if (message.ok) pending.resolve(message.data);
-        else pending.reject(new Error(message.error));
-        return;
-      }
       case 'error':
         this.emit('error', message.message);
         return;

--- a/packages/rrweb/src/replay/embedded/client.ts
+++ b/packages/rrweb/src/replay/embedded/client.ts
@@ -62,8 +62,15 @@ export class EmbeddedReplayerClient {
     // If the host booted before this client attached (e.g. a client re-created
     // on a long-lived iframe), its one-shot `ready` announcement is gone —
     // probe so it re-announces. Harmless when the iframe hasn't loaded yet:
-    // the message is dropped and the host's own boot-time `ready` arrives.
-    this.send({ type: 'ping' });
+    // the message lands on the placeholder document, which has no listener, and
+    // the host's own boot-time `ready` arrives later.
+    //
+    // Targeted at "*" rather than hostOrigin on purpose: a freshly created
+    // iframe is still on its initial about:blank document, which carries the
+    // PARENT's origin, so a hostOrigin-targeted post would be refused and
+    // logged as a console error on every attach. The probe carries no data
+    // beyond its own type, so it is safe to leave the target open.
+    this.probe();
   }
 
   /** Resolves once the host iframe has loaded and announced readiness. */
@@ -166,6 +173,11 @@ export class EmbeddedReplayerClient {
     const target = this.iframe.contentWindow;
     if (!target) return;
     target.postMessage(wrap(command), this.hostOrigin);
+  }
+
+  /** Data-free handshake probe; see the note in the constructor. */
+  private probe(): void {
+    this.iframe.contentWindow?.postMessage(wrap({ type: 'ping' }), '*');
   }
 
   private onMessage = (event: MessageEvent): void => {

--- a/packages/rrweb/src/replay/embedded/host-document.ts
+++ b/packages/rrweb/src/replay/embedded/host-document.ts
@@ -2,20 +2,35 @@
  * Builds the minimal HTML shell that hosts the embedded replayer inside the
  * sandboxed iframe.
  *
- * Intended usage (served-URL mode): serve this document at a static URL and
- * point an iframe at it with `sandbox="allow-scripts"` (NOTE: no
- * `allow-same-origin`). The sandbox attribute forces the document into an
- * opaque origin regardless of the URL it is served from, which is what makes it
- * cookieless and cross-site to the app — so escaped replay JS has no app
- * cookies, no same-origin API access, and no reach into the parent window. The
- * parent origin to trust is passed at runtime via the iframe's `parentOrigin`
- * query parameter, which the host bootstrap reads.
+ * Intended usage: serve this document from a DEDICATED origin that is
+ * cross-site to the embedding app (so it never receives app cookies), and
+ * point an iframe at it with `sandbox="allow-scripts allow-same-origin"`. The
+ * isolation comes from the origin boundary: everything the replayer does runs
+ * with no app cookies, no same-origin access to app APIs, and no reach into the
+ * parent window. The parent origin to trust is passed at runtime via the
+ * iframe's `parentOrigin` query parameter, which the host bootstrap reads.
  *
- * The `<meta>` CSP below governs the realm the replayer ACTUALLY runs in (unlike
- * today's policy, which only covered the rebuilt-DOM child). `script-src` omits
- * `unsafe-eval`, which kills the `new Function(...)` canvas-deserializer path
- * (SEC-8885) even inside the sandbox — defense in depth on top of the origin
- * isolation itself.
+ * `allow-same-origin` is REQUIRED, which is why an opaque-origin
+ * (`allow-scripts`-only) deployment is not possible: nested browsing contexts
+ * inherit the sandbox flags, so inside an opaque-origin document every child
+ * iframe lands in a fresh opaque origin of its own and its `contentDocument`
+ * is unreachable — and the `Replayer` rebuilds the recorded DOM into exactly
+ * such a child iframe (see `createSandboxedIframe` in rrweb-snapshot).
+ * Corollary: NEVER serve this document from the app's own origin — with
+ * `allow-same-origin` the frame would then be same-origin with the app, which
+ * removes the boundary this mode exists to create.
+ *
+ * The `<meta>` CSP below governs the realm the replayer itself runs in, not just
+ * the rebuilt-DOM child document. `script-src` names only the host bundle and
+ * omits `unsafe-eval`, so the replay realm loads no other script and compiles
+ * no code from strings — defense in depth on top of the origin isolation.
+ *
+ * Integration notes:
+ * - This package ships no prebuilt host bundle: `scriptUrl` must point at a
+ *   consumer-built module that calls `startEmbeddedReplayerHost()`.
+ * - Module scripts are CORS-gated: if `scriptUrl` is not same-origin with the
+ *   host document, its server must send `Access-Control-Allow-Origin` for the
+ *   host origin or the host silently never boots.
  */
 
 export interface HostDocumentOptions {

--- a/packages/rrweb/src/replay/embedded/host-document.ts
+++ b/packages/rrweb/src/replay/embedded/host-document.ts
@@ -81,7 +81,7 @@ export function buildHostDocument(options: HostDocumentOptions): string {
 <head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="${escapeAttr(csp)}">
-<style>html,body{margin:0;padding:0;height:100%;overflow:hidden;background:#fff}</style>
+<style>html,body{margin:0;padding:0;height:100%;overflow:hidden;background:transparent}</style>
 ${styleTag}
 <script type="module" src="${escapeAttr(options.scriptUrl)}"></script>
 </head>

--- a/packages/rrweb/src/replay/embedded/host-document.ts
+++ b/packages/rrweb/src/replay/embedded/host-document.ts
@@ -1,0 +1,83 @@
+/**
+ * Builds the minimal HTML shell that hosts the embedded replayer inside the
+ * sandboxed iframe.
+ *
+ * Intended usage (served-URL mode): serve this document at a static URL and
+ * point an iframe at it with `sandbox="allow-scripts"` (NOTE: no
+ * `allow-same-origin`). The sandbox attribute forces the document into an
+ * opaque origin regardless of the URL it is served from, which is what makes it
+ * cookieless and cross-site to the app — so escaped replay JS has no app
+ * cookies, no same-origin API access, and no reach into the parent window. The
+ * parent origin to trust is passed at runtime via the iframe's `parentOrigin`
+ * query parameter, which the host bootstrap reads.
+ *
+ * The `<meta>` CSP below governs the realm the replayer ACTUALLY runs in (unlike
+ * today's policy, which only covered the rebuilt-DOM child). `script-src` omits
+ * `unsafe-eval`, which kills the `new Function(...)` canvas-deserializer path
+ * (SEC-8885) even inside the sandbox — defense in depth on top of the origin
+ * isolation itself.
+ */
+
+export interface HostDocumentOptions {
+  /** Absolute URL of the built host bundle (the module that calls `startEmbeddedReplayerHost`). */
+  scriptUrl: string;
+  /** Optional absolute URL of the rrweb replay stylesheet. */
+  styleUrl?: string;
+  /** Extra values appended to `style-src` (e.g. proxied stylesheet origins). */
+  extraStyleSources?: string[];
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "'self'";
+  }
+}
+
+export function buildHostDocument(options: HostDocumentOptions): string {
+  const scriptOrigin = originOf(options.scriptUrl);
+  const styleSources = [
+    "'unsafe-inline'",
+    scriptOrigin,
+    ...(options.extraStyleSources ?? []),
+  ].join(' ');
+
+  // Strict where it counts (no script beyond our bundle, no eval, no workers,
+  // no outbound connections), permissive for visual assets (fidelity).
+  const csp = [
+    `default-src 'none'`,
+    `script-src ${scriptOrigin}`,
+    `style-src ${styleSources}`,
+    `img-src * data: blob:`,
+    `font-src * data:`,
+    `media-src * data: blob:`,
+    `frame-src *`,
+    `connect-src 'none'`,
+    `worker-src 'none'`,
+  ].join('; ');
+
+  const styleTag = options.styleUrl
+    ? `<link rel="stylesheet" href="${escapeAttr(options.styleUrl)}">`
+    : '';
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${escapeAttr(csp)}">
+<style>html,body{margin:0;padding:0;height:100%;overflow:hidden;background:#fff}</style>
+${styleTag}
+<script type="module" src="${escapeAttr(options.scriptUrl)}"></script>
+</head>
+<body></body>
+</html>`;
+}
+
+function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -2,10 +2,10 @@
  * `EmbeddedReplayerHost` — runs INSIDE the isolated replay iframe.
  *
  * It receives the recorded events + a data-only config from the parent over
- * `postMessage`, constructs a normal rrweb `Replayer` in *this* realm (so all
- * untrusted-data handling — including canvas-argument deserialization — happens
- * here, not in the parent's privileged origin), forwards `Replayer` events back
- * to the parent, and applies playback commands.
+ * `postMessage`, constructs a normal rrweb `Replayer` in *this* realm (so the
+ * replay of untrusted recording data happens here rather than in the parent's
+ * privileged origin), forwards `Replayer` events back to the parent, and
+ * applies playback commands.
  *
  * Security invariants (see ./protocol.ts):
  * - Only messages whose `event.origin` equals the trusted parent origin AND
@@ -88,7 +88,7 @@ export class EmbeddedReplayerHost {
   /** Tear everything down (also invoked on a `destroy` command). */
   stop(): void {
     window.removeEventListener('message', this.onMessage);
-    this.stopTimePump();
+    this.setPlaying(false);
     this.replayer?.destroy();
     this.replayer = null;
     this.started = false;
@@ -113,6 +113,10 @@ export class EmbeddedReplayerHost {
 
   private handle(command: HostCommand): void {
     switch (command.type) {
+      case 'ping':
+        // Re-announce readiness for clients that attached after start().
+        this.post({ type: 'ready' });
+        return;
       case 'init':
         this.init(command.events, command.config, command.autoplay);
         return;
@@ -158,8 +162,10 @@ export class EmbeddedReplayerHost {
     autoplay?: boolean,
   ): void {
     if (this.replayer) {
+      // setPlaying (not a bare stopTimePump) so the `playing` flag resets too;
+      // otherwise the next setPlaying(true) no-ops and the pump never restarts.
+      this.setPlaying(false);
       this.replayer.destroy();
-      this.stopTimePump();
     }
 
     // Data-only config from the parent, plus locally-owned, non-transferable

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -25,6 +25,7 @@ import {
   wrap,
   type HostCommand,
   type HostMessage,
+  type ReplayAnchor,
 } from './protocol';
 
 export interface EmbeddedReplayerHostOptions {
@@ -61,6 +62,12 @@ export class EmbeddedReplayerHost {
   private playing = false;
   private timer: ReturnType<typeof setInterval> | null = null;
   private started = false;
+  /**
+   * Last layout the parent asked for. Retained because each `Replayer` builds
+   * its own wrapper element, so a re-init would otherwise drop the scaling and
+   * render the replay at 1:1 in the corner.
+   */
+  private layout: { scale: number; anchor: ReplayAnchor } | null = null;
 
   constructor(options: EmbeddedReplayerHostOptions = {}) {
     this.root = options.root ?? document.body;
@@ -133,6 +140,14 @@ export class EmbeddedReplayerHost {
         this.replayer?.resume(command.timeOffset ?? 0);
         this.setPlaying(true);
         return;
+      case 'setLayout':
+        this.layout = {
+          scale: command.scale,
+          anchor: command.anchor ?? 'center',
+        };
+        this.applyLayout();
+        this.postDimensions();
+        return;
       case 'setConfig':
         this.replayer?.setConfig(pickSerializableConfig(command.config));
         return;
@@ -178,12 +193,50 @@ export class EmbeddedReplayerHost {
 
     this.replayer = new Replayer(events, replayerConfig);
     this.wireEvents(this.replayer);
+    this.applyLayout(); // new Replayer == new wrapper, so re-apply
     this.postInitialized();
+    this.postDimensions();
 
     if (autoplay) {
       this.replayer.play(0);
       this.setPlaying(true);
     }
+  }
+
+  /**
+   * Translate the parent's layout intent into styles on the replay wrapper.
+   *
+   * Mirrors what an embedder would otherwise apply from its own stylesheet:
+   * `transform-origin: top left` with `left: 50%` to center horizontally, and
+   * either `top: 50%` + a -50% Y translate to center vertically, or `top: 0`
+   * with no Y translate to anchor at the top edge.
+   */
+  private applyLayout(): void {
+    const wrapper = this.replayer?.wrapper;
+    if (!wrapper || !this.layout) return;
+    const { scale, anchor } = this.layout;
+    const top = anchor === 'top';
+    wrapper.style.position = 'absolute';
+    wrapper.style.transformOrigin = 'top left';
+    wrapper.style.left = '50%';
+    wrapper.style.top = top ? '0' : '50%';
+    wrapper.style.transform = top
+      ? `scale(${scale}) translate(-50%, 0)`
+      : `scale(${scale}) translate(-50%, -50%)`;
+  }
+
+  /** Report the wrapper's rendered geometry; the parent cannot measure it. */
+  private postDimensions(): void {
+    const wrapper = this.replayer?.wrapper;
+    if (!wrapper) return;
+    const rect = wrapper.getBoundingClientRect();
+    this.post({
+      type: 'dimensions',
+      width: rect.width,
+      height: rect.height,
+      top: rect.top,
+      left: rect.left,
+    });
   }
 
   /** Push the stable getters (metadata, activity intervals) to the parent. */
@@ -204,6 +257,10 @@ export class EmbeddedReplayerHost {
         if (name === ReplayerEvents.Finish) {
           this.setPlaying(false);
           this.postTime(); // settled end position, after the pump has stopped
+        }
+        if (name === ReplayerEvents.Resize) {
+          // The recorded viewport changed, so the rendered size did too.
+          this.postDimensions();
         }
         this.post(
           PAYLOAD_EVENTS.has(name) && payload !== undefined

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -217,7 +217,10 @@ export class EmbeddedReplayerHost {
     if (this.timer !== null) return;
     this.timer = setInterval(() => {
       if (this.replayer) {
-        this.post({ type: 'time', currentTime: this.replayer.getCurrentTime() });
+        this.post({
+          type: 'time',
+          currentTime: this.replayer.getCurrentTime(),
+        });
       }
     }, this.timeUpdateIntervalMs);
   }
@@ -234,7 +237,10 @@ export class EmbeddedReplayerHost {
     // before the origin is pinned (the `ready` handshake). We never send app
     // secrets over this channel — only replay telemetry — so "*" is acceptable
     // for that single pre-pinning message.
-    this.parentWindow.postMessage(wrap(message), this.expectedParentOrigin ?? '*');
+    this.parentWindow.postMessage(
+      wrap(message),
+      this.expectedParentOrigin ?? '*',
+    );
   }
 }
 

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -25,7 +25,6 @@ import {
   wrap,
   type HostCommand,
   type HostMessage,
-  type HostRequestMethod,
 } from './protocol';
 
 export interface EmbeddedReplayerHostOptions {
@@ -33,8 +32,8 @@ export interface EmbeddedReplayerHostOptions {
    * The exact origin the parent page is served from (e.g.
    * "https://app.launchdarkly.com"). Messages from any other origin are
    * ignored. If omitted, it is read from the `parentOrigin` query parameter of
-   * this iframe's URL; if that is also absent, the host pins the origin of the
-   * first well-formed message it receives and warns.
+   * this iframe's URL; if that is also absent, the host ignores all messages
+   * (and warns once on start).
    */
   expectedParentOrigin?: string;
   /** Element the `Replayer` renders into. Defaults to `document.body`. */
@@ -56,11 +55,11 @@ export class EmbeddedReplayerHost {
   private readonly root: HTMLElement;
   private readonly parentWindow: Window;
   private readonly timeUpdateIntervalMs: number;
-  private expectedParentOrigin: string | null;
+  private readonly expectedParentOrigin: string | null;
 
   private replayer: Replayer | null = null;
   private playing = false;
-  private rafHandle: number | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
   private started = false;
 
   constructor(options: EmbeddedReplayerHostOptions = {}) {
@@ -77,6 +76,11 @@ export class EmbeddedReplayerHost {
   start(): void {
     if (this.started) return;
     this.started = true;
+    if (this.expectedParentOrigin === null) {
+      console.warn(
+        '[rrweb-embedded] no parentOrigin configured; all incoming messages will be ignored',
+      );
+    }
     window.addEventListener('message', this.onMessage);
     this.post({ type: 'ready' });
   }
@@ -91,18 +95,11 @@ export class EmbeddedReplayerHost {
   }
 
   private onMessage = (event: MessageEvent): void => {
-    // Authenticate the peer before looking at anything else.
+    // Authenticate the peer before acting on anything.
     if (event.source !== this.parentWindow) return;
+    if (this.expectedParentOrigin === null) return;
+    if (event.origin !== this.expectedParentOrigin) return;
     if (!isEnvelope<HostCommand>(event.data)) return;
-    if (this.expectedParentOrigin === null) {
-      // No pre-declared parent: trust-on-first-message, then pin.
-      this.expectedParentOrigin = event.origin;
-      console.warn(
-        `[rrweb-embedded] pinning parent origin to "${event.origin}" (no parentOrigin provided)`,
-      );
-    } else if (event.origin !== this.expectedParentOrigin) {
-      return;
-    }
 
     try {
       this.handle(event.data.message);
@@ -135,7 +132,10 @@ export class EmbeddedReplayerHost {
         this.replayer?.setConfig(pickSerializableConfig(command.config));
         return;
       case 'replaceEvents':
-        this.replayer?.replaceEvents(command.events);
+        if (this.replayer) {
+          this.replayer.replaceEvents(command.events);
+          this.postInitialized(); // metadata/intervals may have changed
+        }
         return;
       case 'addEvent':
         this.replayer?.addEvent(command.event);
@@ -148,9 +148,6 @@ export class EmbeddedReplayerHost {
         return;
       case 'destroy':
         this.stop();
-        return;
-      case 'request':
-        this.reply(command.id, command.method);
         return;
     }
   }
@@ -174,8 +171,7 @@ export class EmbeddedReplayerHost {
 
     this.replayer = new Replayer(events, replayerConfig);
     this.wireEvents(this.replayer);
-
-    this.post({ type: 'initialized', metadata: this.replayer.getMetaData() });
+    this.postInitialized();
 
     if (autoplay) {
       this.replayer.play(0);
@@ -183,43 +179,27 @@ export class EmbeddedReplayerHost {
     }
   }
 
+  /** Push the stable getters (metadata, activity intervals) to the parent. */
+  private postInitialized(): void {
+    if (!this.replayer) return;
+    this.post({
+      type: 'initialized',
+      metadata: this.replayer.getMetaData(),
+      activityIntervals: this.replayer.getActivityIntervals(),
+    });
+  }
+
   private wireEvents(replayer: Replayer): void {
     // Forward every Replayer event by name; attach a payload only for the
-    // curated, plainly-serializable ones. A DataCloneError (non-cloneable
-    // payload) degrades to a name-only forward rather than dropping the event.
+    // curated events whose payloads are plain, structured-cloneable data.
     for (const name of Object.values(ReplayerEvents)) {
       replayer.on(name, (payload?: unknown) => {
         if (name === ReplayerEvents.Finish) this.setPlaying(false);
-        const withPayload =
+        this.post(
           PAYLOAD_EVENTS.has(name) && payload !== undefined
-            ? { type: 'replayer-event' as const, event: name, payload }
-            : { type: 'replayer-event' as const, event: name };
-        try {
-          this.post(withPayload);
-        } catch {
-          this.post({ type: 'replayer-event', event: name });
-        }
-      });
-    }
-  }
-
-  private reply(id: number, method: HostRequestMethod): void {
-    if (!this.replayer) {
-      this.post({ type: 'response', id, ok: false, error: 'no replayer' });
-      return;
-    }
-    try {
-      let data: unknown;
-      if (method === 'getMetaData') data = this.replayer.getMetaData();
-      else if (method === 'getCurrentTime') data = this.replayer.getCurrentTime();
-      else data = this.replayer.getActivityIntervals();
-      this.post({ type: 'response', id, ok: true, data });
-    } catch (err) {
-      this.post({
-        type: 'response',
-        id,
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
+            ? { type: 'replayer-event', event: name, payload }
+            : { type: 'replayer-event', event: name },
+        );
       });
     }
   }
@@ -234,23 +214,18 @@ export class EmbeddedReplayerHost {
   }
 
   private startTimePump(): void {
-    if (this.rafHandle !== null) return;
-    let last = 0;
-    const tick = (now: number): void => {
-      if (!this.playing || !this.replayer) return;
-      if (now - last >= this.timeUpdateIntervalMs) {
-        last = now;
+    if (this.timer !== null) return;
+    this.timer = setInterval(() => {
+      if (this.replayer) {
         this.post({ type: 'time', currentTime: this.replayer.getCurrentTime() });
       }
-      this.rafHandle = requestAnimationFrame(tick);
-    };
-    this.rafHandle = requestAnimationFrame(tick);
+    }, this.timeUpdateIntervalMs);
   }
 
   private stopTimePump(): void {
-    if (this.rafHandle !== null) {
-      cancelAnimationFrame(this.rafHandle);
-      this.rafHandle = null;
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
     }
   }
 

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -1,0 +1,277 @@
+/**
+ * `EmbeddedReplayerHost` — runs INSIDE the isolated replay iframe.
+ *
+ * It receives the recorded events + a data-only config from the parent over
+ * `postMessage`, constructs a normal rrweb `Replayer` in *this* realm (so all
+ * untrusted-data handling — including canvas-argument deserialization — happens
+ * here, not in the parent's privileged origin), forwards `Replayer` events back
+ * to the parent, and applies playback commands.
+ *
+ * Security invariants (see ./protocol.ts):
+ * - Only messages whose `event.origin` equals the trusted parent origin AND
+ *   whose `event.source` is our parent window are acted on.
+ * - Message content is only ever treated as data. Config is passed through
+ *   `pickSerializableConfig`, so no function/DOM value from a message reaches
+ *   the `Replayer`. Nothing is `eval`'d or constructed by name from a message.
+ */
+
+import { Replayer } from '../';
+import { ReplayerEvents } from '@rrweb/types';
+import type { eventWithTime } from '@rrweb/types';
+import type { playerConfig } from '../../types';
+import {
+  isEnvelope,
+  pickSerializableConfig,
+  wrap,
+  type HostCommand,
+  type HostMessage,
+  type HostRequestMethod,
+} from './protocol';
+
+export interface EmbeddedReplayerHostOptions {
+  /**
+   * The exact origin the parent page is served from (e.g.
+   * "https://app.launchdarkly.com"). Messages from any other origin are
+   * ignored. If omitted, it is read from the `parentOrigin` query parameter of
+   * this iframe's URL; if that is also absent, the host pins the origin of the
+   * first well-formed message it receives and warns.
+   */
+  expectedParentOrigin?: string;
+  /** Element the `Replayer` renders into. Defaults to `document.body`. */
+  root?: HTMLElement;
+  /** Parent window to post back to. Defaults to `window.parent`. */
+  parentWindow?: Window;
+  /** How often (ms) to push current-time telemetry while playing. */
+  timeUpdateIntervalMs?: number;
+}
+
+/** Events whose payload is small, plain data and useful to the parent UI. */
+const PAYLOAD_EVENTS = new Set<string>([
+  ReplayerEvents.Resize,
+  ReplayerEvents.EventCast,
+  ReplayerEvents.CustomEvent,
+]);
+
+export class EmbeddedReplayerHost {
+  private readonly root: HTMLElement;
+  private readonly parentWindow: Window;
+  private readonly timeUpdateIntervalMs: number;
+  private expectedParentOrigin: string | null;
+
+  private replayer: Replayer | null = null;
+  private playing = false;
+  private rafHandle: number | null = null;
+  private started = false;
+
+  constructor(options: EmbeddedReplayerHostOptions = {}) {
+    this.root = options.root ?? document.body;
+    this.parentWindow = options.parentWindow ?? window.parent;
+    this.timeUpdateIntervalMs = options.timeUpdateIntervalMs ?? 50;
+    this.expectedParentOrigin =
+      options.expectedParentOrigin ??
+      new URLSearchParams(location.search).get('parentOrigin') ??
+      null;
+  }
+
+  /** Install the message listener and announce readiness to the parent. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    window.addEventListener('message', this.onMessage);
+    this.post({ type: 'ready' });
+  }
+
+  /** Tear everything down (also invoked on a `destroy` command). */
+  stop(): void {
+    window.removeEventListener('message', this.onMessage);
+    this.stopTimePump();
+    this.replayer?.destroy();
+    this.replayer = null;
+    this.started = false;
+  }
+
+  private onMessage = (event: MessageEvent): void => {
+    // Authenticate the peer before looking at anything else.
+    if (event.source !== this.parentWindow) return;
+    if (!isEnvelope<HostCommand>(event.data)) return;
+    if (this.expectedParentOrigin === null) {
+      // No pre-declared parent: trust-on-first-message, then pin.
+      this.expectedParentOrigin = event.origin;
+      console.warn(
+        `[rrweb-embedded] pinning parent origin to "${event.origin}" (no parentOrigin provided)`,
+      );
+    } else if (event.origin !== this.expectedParentOrigin) {
+      return;
+    }
+
+    try {
+      this.handle(event.data.message);
+    } catch (err) {
+      this.post({
+        type: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  private handle(command: HostCommand): void {
+    switch (command.type) {
+      case 'init':
+        this.init(command.events, command.config, command.autoplay);
+        return;
+      case 'play':
+        this.replayer?.play(command.timeOffset ?? 0);
+        this.setPlaying(true);
+        return;
+      case 'pause':
+        this.replayer?.pause(command.timeOffset);
+        this.setPlaying(false);
+        return;
+      case 'resume':
+        this.replayer?.resume(command.timeOffset ?? 0);
+        this.setPlaying(true);
+        return;
+      case 'setConfig':
+        this.replayer?.setConfig(pickSerializableConfig(command.config));
+        return;
+      case 'replaceEvents':
+        this.replayer?.replaceEvents(command.events);
+        return;
+      case 'addEvent':
+        this.replayer?.addEvent(command.event);
+        return;
+      case 'enableInteract':
+        this.replayer?.enableInteract();
+        return;
+      case 'disableInteract':
+        this.replayer?.disableInteract();
+        return;
+      case 'destroy':
+        this.stop();
+        return;
+      case 'request':
+        this.reply(command.id, command.method);
+        return;
+    }
+  }
+
+  private init(
+    events: eventWithTime[],
+    config: unknown,
+    autoplay?: boolean,
+  ): void {
+    if (this.replayer) {
+      this.replayer.destroy();
+      this.stopTimePump();
+    }
+
+    // Data-only config from the parent, plus locally-owned, non-transferable
+    // options (the render root and a logger) that never come off the wire.
+    const replayerConfig: Partial<playerConfig> = {
+      ...pickSerializableConfig(config),
+      root: this.root,
+    };
+
+    this.replayer = new Replayer(events, replayerConfig);
+    this.wireEvents(this.replayer);
+
+    this.post({ type: 'initialized', metadata: this.replayer.getMetaData() });
+
+    if (autoplay) {
+      this.replayer.play(0);
+      this.setPlaying(true);
+    }
+  }
+
+  private wireEvents(replayer: Replayer): void {
+    // Forward every Replayer event by name; attach a payload only for the
+    // curated, plainly-serializable ones. A DataCloneError (non-cloneable
+    // payload) degrades to a name-only forward rather than dropping the event.
+    for (const name of Object.values(ReplayerEvents)) {
+      replayer.on(name, (payload?: unknown) => {
+        if (name === ReplayerEvents.Finish) this.setPlaying(false);
+        const withPayload =
+          PAYLOAD_EVENTS.has(name) && payload !== undefined
+            ? { type: 'replayer-event' as const, event: name, payload }
+            : { type: 'replayer-event' as const, event: name };
+        try {
+          this.post(withPayload);
+        } catch {
+          this.post({ type: 'replayer-event', event: name });
+        }
+      });
+    }
+  }
+
+  private reply(id: number, method: HostRequestMethod): void {
+    if (!this.replayer) {
+      this.post({ type: 'response', id, ok: false, error: 'no replayer' });
+      return;
+    }
+    try {
+      let data: unknown;
+      if (method === 'getMetaData') data = this.replayer.getMetaData();
+      else if (method === 'getCurrentTime') data = this.replayer.getCurrentTime();
+      else data = this.replayer.getActivityIntervals();
+      this.post({ type: 'response', id, ok: true, data });
+    } catch (err) {
+      this.post({
+        type: 'response',
+        id,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /* --- current-time telemetry ------------------------------------------- */
+
+  private setPlaying(playing: boolean): void {
+    if (this.playing === playing) return;
+    this.playing = playing;
+    if (playing) this.startTimePump();
+    else this.stopTimePump();
+  }
+
+  private startTimePump(): void {
+    if (this.rafHandle !== null) return;
+    let last = 0;
+    const tick = (now: number): void => {
+      if (!this.playing || !this.replayer) return;
+      if (now - last >= this.timeUpdateIntervalMs) {
+        last = now;
+        this.post({ type: 'time', currentTime: this.replayer.getCurrentTime() });
+      }
+      this.rafHandle = requestAnimationFrame(tick);
+    };
+    this.rafHandle = requestAnimationFrame(tick);
+  }
+
+  private stopTimePump(): void {
+    if (this.rafHandle !== null) {
+      cancelAnimationFrame(this.rafHandle);
+      this.rafHandle = null;
+    }
+  }
+
+  private post(message: HostMessage): void {
+    // Target the known parent origin when we have it; fall back to "*" only
+    // before the origin is pinned (the `ready` handshake). We never send app
+    // secrets over this channel — only replay telemetry — so "*" is acceptable
+    // for that single pre-pinning message.
+    this.parentWindow.postMessage(wrap(message), this.expectedParentOrigin ?? '*');
+  }
+}
+
+/**
+ * Convenience bootstrap for the iframe entry module: construct a host and start
+ * it. The host reads its trusted parent origin from the `parentOrigin` query
+ * parameter unless one is passed explicitly.
+ */
+export function startEmbeddedReplayerHost(
+  options?: EmbeddedReplayerHostOptions,
+): EmbeddedReplayerHost {
+  const host = new EmbeddedReplayerHost(options);
+  host.start();
+  return host;
+}

--- a/packages/rrweb/src/replay/embedded/host.ts
+++ b/packages/rrweb/src/replay/embedded/host.ts
@@ -127,6 +127,7 @@ export class EmbeddedReplayerHost {
       case 'pause':
         this.replayer?.pause(command.timeOffset);
         this.setPlaying(false);
+        this.postTime(); // settled position, after the pump has stopped
         return;
       case 'resume':
         this.replayer?.resume(command.timeOffset ?? 0);
@@ -200,7 +201,10 @@ export class EmbeddedReplayerHost {
     // curated events whose payloads are plain, structured-cloneable data.
     for (const name of Object.values(ReplayerEvents)) {
       replayer.on(name, (payload?: unknown) => {
-        if (name === ReplayerEvents.Finish) this.setPlaying(false);
+        if (name === ReplayerEvents.Finish) {
+          this.setPlaying(false);
+          this.postTime(); // settled end position, after the pump has stopped
+        }
         this.post(
           PAYLOAD_EVENTS.has(name) && payload !== undefined
             ? { type: 'replayer-event', event: name, payload }
@@ -221,14 +225,23 @@ export class EmbeddedReplayerHost {
 
   private startTimePump(): void {
     if (this.timer !== null) return;
-    this.timer = setInterval(() => {
-      if (this.replayer) {
-        this.post({
-          type: 'time',
-          currentTime: this.replayer.getCurrentTime(),
-        });
-      }
-    }, this.timeUpdateIntervalMs);
+    this.timer = setInterval(() => this.postTime(), this.timeUpdateIntervalMs);
+  }
+
+  /**
+   * Push the current playback position across the bridge.
+   *
+   * The parent cannot read the position synchronously — it lives in this realm
+   * behind an origin boundary — so the client's `getCurrentTime()` is only ever
+   * as fresh as the last push. While playing, the pump keeps it current. When
+   * playback stops the pump stops too, so the last pumped value would be up to
+   * one interval stale; callers that seek from it (`play(getCurrentTime())` to
+   * resume) would drift backwards. Pausing and finishing therefore push one
+   * final, settled value.
+   */
+  private postTime(): void {
+    if (!this.replayer) return;
+    this.post({ type: 'time', currentTime: this.replayer.getCurrentTime() });
   }
 
   private stopTimePump(): void {

--- a/packages/rrweb/src/replay/embedded/index.ts
+++ b/packages/rrweb/src/replay/embedded/index.ts
@@ -1,7 +1,8 @@
 /**
- * Origin-isolated replay: run the rrweb `Replayer` inside a cookieless,
- * cross-origin (sandboxed opaque-origin) iframe and drive it from the parent
- * over `postMessage`. See ./protocol.ts for the rationale (SEC-8885).
+ * Origin-isolated replay (opt-in): run the rrweb `Replayer` inside a sandboxed
+ * iframe on a separate, cross-site origin and drive it from the parent over
+ * `postMessage`. See ./protocol.ts for the rationale and the deployment
+ * requirements.
  *
  * - `EmbeddedReplayerHost` / `startEmbeddedReplayerHost`: run inside the iframe.
  * - `EmbeddedReplayerClient`: run in the parent to control the host.

--- a/packages/rrweb/src/replay/embedded/index.ts
+++ b/packages/rrweb/src/replay/embedded/index.ts
@@ -17,6 +17,7 @@ export {
 export {
   EmbeddedReplayerClient,
   type EmbeddedReplayerClientOptions,
+  type ReplayDimensions,
 } from './client';
 export { buildHostDocument, type HostDocumentOptions } from './host-document';
 export {
@@ -28,6 +29,7 @@ export {
   wrap,
   type SerializableReplayerConfig,
   type SerializableConfigKey,
+  type ReplayAnchor,
   type HostCommand,
   type HostMessage,
   type Envelope,

--- a/packages/rrweb/src/replay/embedded/index.ts
+++ b/packages/rrweb/src/replay/embedded/index.ts
@@ -29,7 +29,5 @@ export {
   type SerializableConfigKey,
   type HostCommand,
   type HostMessage,
-  type HostRequestMethod,
-  type PlayerMetaDataLike,
   type Envelope,
 } from './protocol';

--- a/packages/rrweb/src/replay/embedded/index.ts
+++ b/packages/rrweb/src/replay/embedded/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Origin-isolated replay: run the rrweb `Replayer` inside a cookieless,
+ * cross-origin (sandboxed opaque-origin) iframe and drive it from the parent
+ * over `postMessage`. See ./protocol.ts for the rationale (SEC-8885).
+ *
+ * - `EmbeddedReplayerHost` / `startEmbeddedReplayerHost`: run inside the iframe.
+ * - `EmbeddedReplayerClient`: run in the parent to control the host.
+ * - `buildHostDocument`: HTML shell for the sandboxed iframe.
+ */
+
+export {
+  EmbeddedReplayerHost,
+  startEmbeddedReplayerHost,
+  type EmbeddedReplayerHostOptions,
+} from './host';
+export {
+  EmbeddedReplayerClient,
+  type EmbeddedReplayerClientOptions,
+} from './client';
+export { buildHostDocument, type HostDocumentOptions } from './host-document';
+export {
+  RRWEB_EMBEDDED_CHANNEL,
+  RRWEB_EMBEDDED_PROTOCOL_VERSION,
+  SERIALIZABLE_CONFIG_KEYS,
+  pickSerializableConfig,
+  isEnvelope,
+  wrap,
+  type SerializableReplayerConfig,
+  type SerializableConfigKey,
+  type HostCommand,
+  type HostMessage,
+  type HostRequestMethod,
+  type PlayerMetaDataLike,
+  type Envelope,
+} from './protocol';

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -96,7 +96,12 @@ export function pickSerializableConfig(
 /* -------------------------------------------------------------------------- */
 
 export type HostCommand =
-  | { type: 'init'; events: eventWithTime[]; config?: SerializableReplayerConfig; autoplay?: boolean }
+  | {
+      type: 'init';
+      events: eventWithTime[];
+      config?: SerializableReplayerConfig;
+      autoplay?: boolean;
+    }
   | { type: 'play'; timeOffset?: number }
   | { type: 'pause'; timeOffset?: number }
   | { type: 'resume'; timeOffset?: number }

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -1,0 +1,174 @@
+/**
+ * Wire protocol for running the rrweb `Replayer` inside an isolated iframe and
+ * driving it from a parent page over `postMessage`.
+ *
+ * Motivation (SEC-8885): today the `Replayer` runs in the host page and rebuilds
+ * the recorded DOM downward into a child iframe. Canvas replay reconstructs
+ * command arguments via `new window[rr_type](...)` in that host realm, so a
+ * poisoned `Promise(Function("code"))` executes as first-party JS on the app
+ * origin. Relocating the `Replayer` *into* a cookieless, cross-origin iframe
+ * moves every bit of untrusted-data handling out of the privileged origin: even
+ * if attacker JS runs, it runs somewhere with no app cookies, no same-origin API
+ * access, and no reach into the parent window.
+ *
+ * This module defines the messages exchanged across that boundary. Two rules are
+ * load-bearing and MUST hold for the isolation to be worth anything:
+ *
+ * 1. Every payload is plain, structured-cloneable DATA. Neither side ever sends
+ *    a function, and neither side ever `eval`s / constructs anything from a
+ *    message. The host constructs a `Replayer` from event data; it never turns
+ *    message content into code.
+ * 2. Both sides authenticate their peer before acting on a message. The host
+ *    checks `event.origin` against the parent origin it was told to trust; the
+ *    client checks `event.source` identity against its iframe's `contentWindow`
+ *    (a sandboxed opaque-origin iframe reports `event.origin === "null"`, so
+ *    origin-string matching is not usable on the client side).
+ */
+
+import type { playerConfig } from '../../types';
+import type { eventWithTime } from '@rrweb/types';
+
+/** Namespaces our traffic so unrelated `postMessage` chatter is ignored. */
+export const RRWEB_EMBEDDED_CHANNEL = 'rrweb-embedded' as const;
+
+/** Bump on any breaking change to the message shapes below. */
+export const RRWEB_EMBEDDED_PROTOCOL_VERSION = 1 as const;
+
+/**
+ * The subset of `playerConfig` that is safe to send across the boundary: plain
+ * data only. `root` (a DOM node), `unpackFn`/`logger` (functions) and `plugins`
+ * (functions) are deliberately excluded — the host supplies those locally and
+ * never accepts them from a message. Keep this list in sync with the type below.
+ */
+export const SERIALIZABLE_CONFIG_KEYS = [
+  'speed',
+  'maxSpeed',
+  'loadTimeout',
+  'skipInactive',
+  'inactivePeriodThreshold',
+  'showWarning',
+  'showDebug',
+  'blockClass',
+  'liveMode',
+  'insertStyleRules',
+  'triggerFocus',
+  'UNSAFE_replayCanvas',
+  'cspContent',
+  'pauseAnimation',
+  'mouseTail',
+  'useVirtualDom',
+  'inactiveThreshold',
+  'inactiveSkipTime',
+] as const;
+
+export type SerializableConfigKey = (typeof SERIALIZABLE_CONFIG_KEYS)[number];
+
+/** Data-only config the parent may hand the host. */
+export type SerializableReplayerConfig = Partial<
+  Pick<playerConfig, SerializableConfigKey>
+>;
+
+/**
+ * Copy only allowlisted, data-only keys off an untrusted config-shaped value.
+ * Anything else (including functions and DOM nodes) is dropped.
+ */
+export function pickSerializableConfig(
+  config: unknown,
+): SerializableReplayerConfig {
+  const out: Record<string, unknown> = {};
+  if (config && typeof config === 'object') {
+    for (const key of SERIALIZABLE_CONFIG_KEYS) {
+      const value = (config as Record<string, unknown>)[key];
+      if (value !== undefined && typeof value !== 'function') {
+        out[key] = value;
+      }
+    }
+  }
+  return out as SerializableReplayerConfig;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Parent -> Host (commands)                                                  */
+/* -------------------------------------------------------------------------- */
+
+export type HostCommand =
+  | { type: 'init'; events: eventWithTime[]; config?: SerializableReplayerConfig; autoplay?: boolean }
+  | { type: 'play'; timeOffset?: number }
+  | { type: 'pause'; timeOffset?: number }
+  | { type: 'resume'; timeOffset?: number }
+  | { type: 'setConfig'; config: SerializableReplayerConfig }
+  | { type: 'replaceEvents'; events: eventWithTime[] }
+  | { type: 'addEvent'; event: eventWithTime }
+  | { type: 'enableInteract' }
+  | { type: 'disableInteract' }
+  | { type: 'destroy' }
+  | { type: 'request'; id: number; method: HostRequestMethod };
+
+/** Getter RPCs the parent can await a reply to. */
+export type HostRequestMethod =
+  | 'getMetaData'
+  | 'getCurrentTime'
+  | 'getActivityIntervals';
+
+/* -------------------------------------------------------------------------- */
+/* Host -> Parent (events / telemetry / replies)                              */
+/* -------------------------------------------------------------------------- */
+
+export type HostMessage =
+  /** Host script booted and the message listener is installed (pre-init). */
+  | { type: 'ready' }
+  /** `Replayer` constructed; carries its (serializable) metadata. */
+  | { type: 'initialized'; metadata: PlayerMetaDataLike }
+  /** A forwarded `Replayer` event (`replayer.on(...)`). Payload is optional and always plain data. */
+  | { type: 'replayer-event'; event: string; payload?: SerializablePayload }
+  /** Periodic current-time push while playing, so the parent scrubber can track without sync getters. */
+  | { type: 'time'; currentTime: number }
+  /** Reply to a `request` command. */
+  | { type: 'response'; id: number; ok: true; data: SerializablePayload }
+  | { type: 'response'; id: number; ok: false; error: string }
+  /** Host-side failure surfaced for logging. */
+  | { type: 'error'; message: string };
+
+export type PlayerMetaDataLike = {
+  startTime: number;
+  endTime: number;
+  totalTime: number;
+};
+
+/** Anything that survives structured clone; kept loose on purpose. */
+export type SerializablePayload = unknown;
+
+/* -------------------------------------------------------------------------- */
+/* Envelope + guards                                                          */
+/* -------------------------------------------------------------------------- */
+
+export interface Envelope<T> {
+  channel: typeof RRWEB_EMBEDDED_CHANNEL;
+  version: typeof RRWEB_EMBEDDED_PROTOCOL_VERSION;
+  message: T;
+}
+
+export function wrap<T>(message: T): Envelope<T> {
+  return {
+    channel: RRWEB_EMBEDDED_CHANNEL,
+    version: RRWEB_EMBEDDED_PROTOCOL_VERSION,
+    message,
+  };
+}
+
+/**
+ * Validate that an arbitrary `postMessage` datum is one of our envelopes on the
+ * expected protocol version. Does not trust the sender — callers must still
+ * authenticate origin/source before acting.
+ */
+export function isEnvelope<T = unknown>(data: unknown): data is Envelope<T> {
+  if (!data || typeof data !== 'object') return false;
+  const e = data as Partial<Envelope<T>>;
+  return (
+    e.channel === RRWEB_EMBEDDED_CHANNEL &&
+    e.version === RRWEB_EMBEDDED_PROTOCOL_VERSION &&
+    !!e.message &&
+    typeof e.message === 'object' &&
+    typeof (e.message as { type?: unknown }).type === 'string'
+  );
+}

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -26,7 +26,11 @@
  */
 
 import type { playerConfig } from '../../types';
-import type { eventWithTime } from '@rrweb/types';
+import type {
+  eventWithTime,
+  playerMetaData,
+  SessionInterval,
+} from '@rrweb/types';
 
 /** Namespaces our traffic so unrelated `postMessage` chatter is ignored. */
 export const RRWEB_EMBEDDED_CHANNEL = 'rrweb-embedded' as const;
@@ -101,14 +105,7 @@ export type HostCommand =
   | { type: 'addEvent'; event: eventWithTime }
   | { type: 'enableInteract' }
   | { type: 'disableInteract' }
-  | { type: 'destroy' }
-  | { type: 'request'; id: number; method: HostRequestMethod };
-
-/** Getter RPCs the parent can await a reply to. */
-export type HostRequestMethod =
-  | 'getMetaData'
-  | 'getCurrentTime'
-  | 'getActivityIntervals';
+  | { type: 'destroy' };
 
 /* -------------------------------------------------------------------------- */
 /* Host -> Parent (events / telemetry / replies)                              */
@@ -117,26 +114,22 @@ export type HostRequestMethod =
 export type HostMessage =
   /** Host script booted and the message listener is installed (pre-init). */
   | { type: 'ready' }
-  /** `Replayer` constructed; carries its (serializable) metadata. */
-  | { type: 'initialized'; metadata: PlayerMetaDataLike }
+  /**
+   * `Replayer` constructed (or its events replaced). Carries the stable getters
+   * the viewer needs — metadata and activity intervals — so the parent reads
+   * them from cache instead of pulling them synchronously across the boundary.
+   */
+  | {
+      type: 'initialized';
+      metadata: playerMetaData;
+      activityIntervals: SessionInterval[];
+    }
   /** A forwarded `Replayer` event (`replayer.on(...)`). Payload is optional and always plain data. */
-  | { type: 'replayer-event'; event: string; payload?: SerializablePayload }
+  | { type: 'replayer-event'; event: string; payload?: unknown }
   /** Periodic current-time push while playing, so the parent scrubber can track without sync getters. */
   | { type: 'time'; currentTime: number }
-  /** Reply to a `request` command. */
-  | { type: 'response'; id: number; ok: true; data: SerializablePayload }
-  | { type: 'response'; id: number; ok: false; error: string }
   /** Host-side failure surfaced for logging. */
   | { type: 'error'; message: string };
-
-export type PlayerMetaDataLike = {
-  startTime: number;
-  endTime: number;
-  totalTime: number;
-};
-
-/** Anything that survives structured clone; kept loose on purpose. */
-export type SerializablePayload = unknown;
 
 /* -------------------------------------------------------------------------- */
 /* Envelope + guards                                                          */

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -94,6 +94,13 @@ export function pickSerializableConfig(
 /* Parent -> Host (commands)                                                  */
 /* -------------------------------------------------------------------------- */
 
+/**
+ * Where the scaled replay sits in the host viewport. `center` centers it on
+ * both axes; `top` centers horizontally and anchors to the top edge, so the
+ * replay grows downward as the frame gets taller.
+ */
+export type ReplayAnchor = 'top' | 'center';
+
 export type HostCommand =
   /**
    * Handshake probe. The host answers with `ready`. Sent by the client on
@@ -107,6 +114,17 @@ export type HostCommand =
       config?: SerializableReplayerConfig;
       autoplay?: boolean;
     }
+  /**
+   * Scale and position the replay inside the host viewport.
+   *
+   * The embedder computes `scale` itself — it knows its own container size and
+   * the recorded viewport — but cannot apply it, because the replay wrapper
+   * lives in the host realm. So intent crosses the boundary and the host
+   * translates it into styles. Deliberately NOT a CSS string or class name: a
+   * class from the embedder's stylesheet means nothing in the host document and
+   * would silently do nothing.
+   */
+  | { type: 'setLayout'; scale: number; anchor?: ReplayAnchor }
   | { type: 'play'; timeOffset?: number }
   | { type: 'pause'; timeOffset?: number }
   | { type: 'resume'; timeOffset?: number }
@@ -138,6 +156,18 @@ export type HostMessage =
   | { type: 'replayer-event'; event: string; payload?: unknown }
   /** Periodic current-time push while playing, so the parent scrubber can track without sync getters. */
   | { type: 'time'; currentTime: number }
+  /**
+   * Rendered geometry of the replay wrapper, in the host document's coordinate
+   * space. The parent cannot measure across the boundary, so the host reports
+   * it after init, after a layout change, and whenever the replay resizes.
+   */
+  | {
+      type: 'dimensions';
+      width: number;
+      height: number;
+      top: number;
+      left: number;
+    }
   /** Host-side failure surfaced for logging. */
   | { type: 'error'; message: string };
 

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -2,14 +2,13 @@
  * Wire protocol for running the rrweb `Replayer` inside an isolated iframe and
  * driving it from a parent page over `postMessage`.
  *
- * Motivation (SEC-8885): today the `Replayer` runs in the host page and rebuilds
- * the recorded DOM downward into a child iframe. Canvas replay reconstructs
- * command arguments via `new window[rr_type](...)` in that host realm, so a
- * poisoned `Promise(Function("code"))` executes as first-party JS on the app
- * origin. Relocating the `Replayer` *into* a cookieless, cross-origin iframe
- * moves every bit of untrusted-data handling out of the privileged origin: even
- * if attacker JS runs, it runs somewhere with no app cookies, no same-origin API
- * access, and no reach into the parent window.
+ * Motivation: a recorded session is untrusted input, and by default the
+ * `Replayer` runs in the embedding page's own realm — so the whole replay path
+ * operates with the embedding origin's privileges. This opt-in mode lets an
+ * embedder relocate the `Replayer` into a separate, cross-site origin instead,
+ * where it has no app cookies, no same-origin access to app APIs, and no reach
+ * into the parent window. Purely additive: in-parent `Replayer` usage is
+ * unchanged, and embedders who do not opt in are unaffected.
  *
  * This module defines the messages exchanged across that boundary. Two rules are
  * load-bearing and MUST hold for the isolation to be worth anything:
@@ -20,9 +19,9 @@
  *    message content into code.
  * 2. Both sides authenticate their peer before acting on a message. The host
  *    checks `event.origin` against the parent origin it was told to trust; the
- *    client checks `event.source` identity against its iframe's `contentWindow`
- *    (a sandboxed opaque-origin iframe reports `event.origin === "null"`, so
- *    origin-string matching is not usable on the client side).
+ *    client checks `event.source` identity against its iframe's
+ *    `contentWindow`, which holds regardless of the origin the host document
+ *    is served from.
  */
 
 import type { playerConfig } from '../../types';
@@ -96,6 +95,12 @@ export function pickSerializableConfig(
 /* -------------------------------------------------------------------------- */
 
 export type HostCommand =
+  /**
+   * Handshake probe. The host answers with `ready`. Sent by the client on
+   * construction so that a client attached to an already-booted host (whose
+   * one-shot `ready` announcement it missed) still resolves `whenReady()`.
+   */
+  | { type: 'ping' }
   | {
       type: 'init';
       events: eventWithTime[];

--- a/packages/rrweb/test/html/embedded-host.html
+++ b/packages/rrweb/test/html/embedded-host.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>embedded replayer host</title>
+  </head>
+  <body>
+    <!-- Serves the embedded replayer host for the e2e suite. The trusted
+         parent origin arrives via the ?parentOrigin= query parameter, which
+         startEmbeddedReplayerHost() reads — the same served-URL wiring the
+         real integration uses. -->
+    <script src="/rrweb.umd.cjs"></script>
+    <script>
+      window.rrweb.startEmbeddedReplayerHost({ timeUpdateIntervalMs: 20 });
+    </script>
+  </body>
+</html>

--- a/packages/rrweb/test/integration.test.ts
+++ b/packages/rrweb/test/integration.test.ts
@@ -9,6 +9,7 @@ import {
   launchPuppeteer,
   waitForRAF,
   waitForIFrameLoad,
+  replaceFirst,
   replaceLast,
   generateRecordSnippet,
   ISuite,
@@ -1221,8 +1222,9 @@ describe('record integration tests', function (this: ISuite) {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');
     await page.setContent(
-      // insert shadydom script
-      replaceLast(
+      // insert shadydom script (first '<head>' = the document's real head; the
+      // inlined rrweb bundle also contains that text in a string literal)
+      replaceFirst(
         getHtml.call(this, 'polyfilled-shadowdom-mutation.html'),
         '<head>',
         `
@@ -1255,8 +1257,9 @@ describe('record integration tests', function (this: ISuite) {
     const page: puppeteer.Page = await browser.newPage();
     await page.goto('about:blank');
     await page.setContent(
-      // insert lwc's synthetic-shadow script
-      replaceLast(
+      // insert lwc's synthetic-shadow script (first '<head>' = the document's
+      // real head; the inlined rrweb bundle also contains that text)
+      replaceFirst(
         getHtml.call(this, 'polyfilled-shadowdom-mutation.html'),
         '<head>',
         `

--- a/packages/rrweb/test/replay/embedded-e2e.test.ts
+++ b/packages/rrweb/test/replay/embedded-e2e.test.ts
@@ -1,0 +1,198 @@
+/**
+ * End-to-end coverage for the optional origin-isolated embedded replayer: boots
+ * a real `EmbeddedReplayerHost` (and `Replayer`) inside a sandboxed cross-origin
+ * iframe and drives it from a parent page on a different origin with a real
+ * `EmbeddedReplayerClient` over `postMessage`.
+ *
+ * Deployment-shape note: the host runs with
+ * `sandbox="allow-scripts allow-same-origin"` on a DEDICATED origin (here: a
+ * second localhost port). `allow-same-origin` is required — without it the
+ * host document gets an opaque origin, its nested browsing contexts inherit
+ * the sandbox flags and land in fresh opaque origins of their own, and the
+ * `Replayer`'s rebuild iframe becomes unreachable (`contentDocument` is null),
+ * so replay cannot work at all. Isolation comes from the host origin being
+ * cross-site to the app, not from origin opacity.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import type * as puppeteer from 'puppeteer';
+import { vi } from 'vitest';
+import { startServer, getServerURL, launchPuppeteer, ISuite } from '../utils';
+import rawEvents from '../events/hover';
+
+describe('embedded replayer e2e', function (this: ISuite) {
+  vi.setConfig({ testTimeout: 30_000 });
+
+  let code: ISuite['code'];
+  let browser: ISuite['browser'];
+  let parentServer: ISuite['server'];
+  let hostServer: ISuite['server'];
+  let parentServerURL: string;
+  let hostServerURL: string;
+  let page: puppeteer.Page;
+
+  // Stretch the fixture (~155ms) so playback runs long enough to observe the
+  // current-time telemetry stream across several pump ticks.
+  const events = rawEvents.map((e) => ({ ...e, timestamp: e.timestamp * 30 }));
+  const eventsJson = JSON.stringify(events);
+
+  beforeAll(async () => {
+    // Two servers on different ports = two origins, so the host iframe is
+    // genuinely cross-origin to the parent page, like the real deployment.
+    parentServer = await startServer();
+    hostServer = await startServer(3031);
+    parentServerURL = getServerURL(parentServer);
+    hostServerURL = getServerURL(hostServer);
+    browser = await launchPuppeteer();
+    const bundlePath = path.resolve(__dirname, '../../dist/rrweb.umd.cjs');
+    code = fs.readFileSync(bundlePath, 'utf8');
+  });
+
+  afterEach(async () => {
+    await page?.close();
+  });
+
+  afterAll(async () => {
+    await browser.close();
+    parentServer.close();
+    hostServer.close();
+  });
+
+  /**
+   * Load a parent page on origin A, embed the served host page from origin B
+   * in a sandboxed iframe, and attach a client. Leaves `__client`, `__iframe`,
+   * `__received`, and `__eventsJson` on the parent window for tests to drive.
+   */
+  async function bootEmbedded(): Promise<void> {
+    page = await browser.newPage();
+    await page.goto(`${parentServerURL}/html/`);
+    await page.setContent(
+      `<!DOCTYPE html><html><body><script>${code}</script></body></html>`,
+    );
+    await page.evaluate(
+      (hostPageURL, evJson) => {
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const w = window as any;
+        w.__eventsJson = evJson;
+        const iframe = document.createElement('iframe');
+        iframe.setAttribute('sandbox', 'allow-scripts allow-same-origin');
+        iframe.src =
+          hostPageURL + '?parentOrigin=' + encodeURIComponent(location.origin);
+        document.body.appendChild(iframe);
+        w.__iframe = iframe;
+
+        const received = {
+          initializedCount: 0,
+          metadata: null as unknown,
+          times: [] as number[],
+          replayerEvents: [] as string[],
+          errors: [] as string[],
+        };
+        w.__received = received;
+
+        const client = new w.rrweb.EmbeddedReplayerClient(iframe, {
+          hostOrigin: new URL(hostPageURL).origin,
+        });
+        w.__client = client;
+        client.on('initialized', (m: unknown) => {
+          received.initializedCount += 1;
+          received.metadata = m;
+        });
+        client.on('time', (t: number) => received.times.push(t));
+        client.on('fullsnapshot-rebuilded', () =>
+          received.replayerEvents.push('fullsnapshot-rebuilded'),
+        );
+        client.on('error', (message: string) => received.errors.push(message));
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+      },
+      `${hostServerURL}/html/embedded-host.html`,
+      eventsJson,
+    );
+    // The host announces `ready` once the served host page boots.
+    const ready = await page.evaluate(`
+      Promise.race([
+        window.__client.whenReady().then(() => 'ready'),
+        new Promise((resolve) => setTimeout(() => resolve('timed out'), 15000)),
+      ])
+    `);
+    if (ready !== 'ready') {
+      throw new Error('embedded host never announced ready');
+    }
+  }
+
+  it('completes the ready handshake, builds the replay cross-origin, and reports metadata', async () => {
+    await bootEmbedded();
+
+    const crossOriginBlocked = await page.evaluate(
+      'window.__iframe.contentDocument === null',
+    );
+    // The parent must NOT be able to reach into the host document — removing
+    // that reachability is the point of the isolation.
+    expect(crossOriginBlocked).toBe(true);
+
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, false)',
+    );
+    await page.waitForFunction('window.__received.initializedCount > 0');
+    await page.waitForFunction(
+      'window.__received.replayerEvents.includes("fullsnapshot-rebuilded")',
+    );
+
+    const errors = (await page.evaluate(
+      'window.__received.errors',
+    )) as string[];
+    expect(errors).toEqual([]);
+
+    const metadata = (await page.evaluate('window.__received.metadata')) as {
+      totalTime: number;
+    };
+    expect(metadata.totalTime).toBeGreaterThan(0);
+    const cachedMetadata = await page.evaluate('window.__client.getMetaData()');
+    expect(cachedMetadata).toEqual(metadata);
+  });
+
+  it('streams time updates while playing, including after a re-init while already playing', async () => {
+    await bootEmbedded();
+
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, false)',
+    );
+    await page.waitForFunction('window.__received.initializedCount > 0');
+
+    await page.evaluate('window.__client.play(0)');
+    await page.waitForFunction('window.__received.times.length >= 3');
+
+    // Re-init while the previous replayer is still playing. The host must
+    // reset its playing state so the autoplay below restarts the time pump —
+    // regression test for the pump dying after re-init.
+    const before = (await page.evaluate(
+      'window.__received.times.length',
+    )) as number;
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, true)',
+    );
+    await page.waitForFunction('window.__received.initializedCount >= 2');
+    await page.waitForFunction(
+      `window.__received.times.length >= ${before + 3}`,
+      { timeout: 10_000 },
+    );
+  });
+
+  it('resolves whenReady for a client attached after the host booted', async () => {
+    await bootEmbedded();
+
+    // The first client consumed the boot-time `ready`. A second client on the
+    // same long-lived iframe must still hand-shake (via its construction ping)
+    // instead of hanging forever — regression test for the missed-`ready` race.
+    const result = await page.evaluate(`
+      (() => {
+        const c2 = new window.rrweb.EmbeddedReplayerClient(window.__iframe);
+        return Promise.race([
+          c2.whenReady().then(() => 'ready'),
+          new Promise((resolve) => setTimeout(() => resolve('timed out'), 5000)),
+        ]);
+      })()
+    `);
+    expect(result).toBe('ready');
+  });
+});

--- a/packages/rrweb/test/replay/embedded-e2e.test.ts
+++ b/packages/rrweb/test/replay/embedded-e2e.test.ts
@@ -87,6 +87,7 @@ describe('embedded replayer e2e', function (this: ISuite) {
           times: [] as number[],
           replayerEvents: [] as string[],
           errors: [] as string[],
+          dimensionsCount: 0,
         };
         w.__received = received;
 
@@ -103,6 +104,9 @@ describe('embedded replayer e2e', function (this: ISuite) {
           received.replayerEvents.push('fullsnapshot-rebuilded'),
         );
         client.on('error', (message: string) => received.errors.push(message));
+        client.on('dimensions', () => {
+          received.dimensionsCount += 1;
+        });
         /* eslint-enable @typescript-eslint/no-explicit-any */
       },
       `${hostServerURL}/html/embedded-host.html`,
@@ -220,6 +224,64 @@ describe('embedded replayer e2e', function (this: ISuite) {
     expect(
       (await page.evaluate('window.__received.times')) as number[],
     ).not.toContain(0);
+  });
+
+  it('applies parent-driven scaling in the host realm and reports the geometry back', async () => {
+    await bootEmbedded();
+
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, false)',
+    );
+    await page.waitForFunction('window.__client.getDimensions() !== null');
+
+    const dims = () =>
+      page.evaluate('window.__client.getDimensions()') as Promise<{
+        width: number;
+        height: number;
+        top: number;
+        left: number;
+      }>;
+
+    // Scaling is applied to a wrapper the parent cannot touch or measure, so
+    // the reported geometry is the only observable. Halving the scale must
+    // halve the reported size.
+    await page.evaluate('window.__client.setLayout(1, "center")');
+    await page.waitForFunction('window.__client.getDimensions().width > 0');
+    const full = await dims();
+
+    await page.evaluate('window.__client.setLayout(0.5, "center")');
+    await page.waitForFunction(
+      `Math.abs(window.__client.getDimensions().width - ${full.width / 2}) < 2`,
+      { timeout: 10_000 },
+    );
+    const half = await dims();
+    expect(half.height).toBeCloseTo(full.height / 2, 0);
+
+    // Anchoring must move the replay without resizing it: a top anchor puts the
+    // wrapper's top edge at the top of the host viewport.
+    await page.evaluate('window.__client.setLayout(0.5, "top")');
+    await page.waitForFunction(
+      'Math.abs(window.__client.getDimensions().top) < 2',
+      { timeout: 10_000 },
+    );
+    const topAnchored = await dims();
+    expect(topAnchored.width).toBeCloseTo(half.width, 0);
+    expect(Math.abs(topAnchored.top - half.top)).toBeGreaterThan(1);
+
+    // A re-init builds a new Replayer, and therefore a new wrapper. The host
+    // must re-apply the retained layout or the replay would snap back to 1:1.
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, false)',
+    );
+    await page.waitForFunction('window.__received.initializedCount >= 2');
+    await page.waitForFunction(
+      `Math.abs(window.__client.getDimensions().width - ${half.width}) < 2`,
+      { timeout: 10_000 },
+    );
+
+    expect(
+      (await page.evaluate('window.__received.errors')) as string[],
+    ).toEqual([]);
   });
 
   it('resolves whenReady for a client attached after the host booted', async () => {

--- a/packages/rrweb/test/replay/embedded-e2e.test.ts
+++ b/packages/rrweb/test/replay/embedded-e2e.test.ts
@@ -178,6 +178,50 @@ describe('embedded replayer e2e', function (this: ISuite) {
     );
   });
 
+  it('pushes a settled position on pause, so the parent can resume without rewinding', async () => {
+    await bootEmbedded();
+
+    await page.evaluate(
+      'window.__client.init(JSON.parse(window.__eventsJson), {}, false)',
+    );
+    await page.waitForFunction('window.__received.initializedCount > 0');
+
+    await page.evaluate('window.__client.play(0)');
+    await page.waitForFunction('window.__received.times.length >= 3');
+
+    // Seek-and-pause far ahead of where playback currently is (a few hundred ms
+    // in). Any pump tick still in flight reports the old position, so only a
+    // final push made *after* the pause can land near the seek target.
+    const SEEK_TO = 3000;
+    await page.evaluate(`window.__client.pause(${SEEK_TO})`);
+    await page.waitForFunction(
+      `Math.abs(window.__client.getCurrentTime() - ${SEEK_TO}) < 250`,
+      { timeout: 10_000 },
+    );
+
+    // The position must also hold still while paused — no further pushes.
+    const atRest = (await page.evaluate(
+      'window.__client.getCurrentTime()',
+    )) as number;
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    expect(await page.evaluate('window.__client.getCurrentTime()')).toBe(
+      atRest,
+    );
+
+    // Resuming from the cached position must continue forward from there rather
+    // than restart, which is what a viewer's play button has to do given that
+    // Replayer.play(timeOffset) always seeks.
+    await page.evaluate(
+      'window.__client.play(window.__client.getCurrentTime())',
+    );
+    await page.waitForFunction(`window.__client.getCurrentTime() > ${atRest}`, {
+      timeout: 10_000,
+    });
+    expect(
+      (await page.evaluate('window.__received.times')) as number[],
+    ).not.toContain(0);
+  });
+
   it('resolves whenReady for a client attached after the host booted', async () => {
     await bootEmbedded();
 

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -126,6 +126,52 @@ describe('EmbeddedReplayerClient', () => {
     });
   });
 
+  it('sends layout intent, not styles, and defaults the anchor host-side', () => {
+    const { client, posted } = makeClient();
+    client.setLayout(0.5, 'top');
+    expect(posted[1]).toMatchObject({
+      message: { type: 'setLayout', scale: 0.5, anchor: 'top' },
+    });
+
+    // Anchor omitted: the host applies its own default rather than the client
+    // inventing one, so both sides agree on exactly one default.
+    client.setLayout(0.25);
+    expect(posted[2]).toMatchObject({
+      message: { type: 'setLayout', scale: 0.25 },
+    });
+    expect(
+      (posted[2] as { message: Record<string, unknown> }).message.anchor,
+    ).toBeUndefined();
+  });
+
+  it('caches reported dimensions and emits them', () => {
+    const { client } = makeClient();
+    expect(client.getDimensions()).toBeNull();
+    const onDimensions = vi.fn();
+    client.on('dimensions', onDimensions);
+
+    deliver({
+      type: 'dimensions',
+      width: 452,
+      height: 242,
+      top: 119,
+      left: 224,
+    });
+
+    expect(client.getDimensions()).toEqual({
+      width: 452,
+      height: 242,
+      top: 119,
+      left: 224,
+    });
+    expect(onDimensions).toHaveBeenCalledWith({
+      width: 452,
+      height: 242,
+      top: 119,
+      left: 224,
+    });
+  });
+
   it('resolves whenReady on the ready handshake', async () => {
     const { client } = makeClient();
     let resolved = false;

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  isEnvelope,
+  pickSerializableConfig,
+  wrap,
+  RRWEB_EMBEDDED_CHANNEL,
+  RRWEB_EMBEDDED_PROTOCOL_VERSION,
+  type HostMessage,
+} from '../../src/replay/embedded/protocol';
+import { EmbeddedReplayerClient } from '../../src/replay/embedded/client';
+
+describe('embedded replay protocol', () => {
+  describe('isEnvelope', () => {
+    it('accepts a well-formed envelope', () => {
+      expect(isEnvelope(wrap({ type: 'ready' }))).toBe(true);
+    });
+
+    it('rejects wrong channel / version / shape', () => {
+      expect(isEnvelope(null)).toBe(false);
+      expect(isEnvelope({})).toBe(false);
+      expect(
+        isEnvelope({ channel: 'other', version: 1, message: { type: 'ready' } }),
+      ).toBe(false);
+      expect(
+        isEnvelope({
+          channel: RRWEB_EMBEDDED_CHANNEL,
+          version: 999,
+          message: { type: 'ready' },
+        }),
+      ).toBe(false);
+      // message without a string `type`
+      expect(
+        isEnvelope({
+          channel: RRWEB_EMBEDDED_CHANNEL,
+          version: RRWEB_EMBEDDED_PROTOCOL_VERSION,
+          message: {},
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('pickSerializableConfig', () => {
+    it('keeps allowlisted data keys', () => {
+      const out = pickSerializableConfig({
+        speed: 2,
+        skipInactive: true,
+        UNSAFE_replayCanvas: false,
+        cspContent: "script-src 'none'",
+      });
+      expect(out).toEqual({
+        speed: 2,
+        skipInactive: true,
+        UNSAFE_replayCanvas: false,
+        cspContent: "script-src 'none'",
+      });
+    });
+
+    it('drops functions, DOM-ish values, and unknown keys', () => {
+      const out = pickSerializableConfig({
+        speed: 1,
+        root: { nodeType: 1 }, // not allowlisted -> dropped
+        unpackFn: () => 'x', // function -> dropped
+        logger: { log: () => undefined }, // not allowlisted -> dropped
+        plugins: [() => undefined], // not allowlisted -> dropped
+        somethingElse: 'nope', // unknown -> dropped
+      });
+      expect(out).toEqual({ speed: 1 });
+      expect('root' in out).toBe(false);
+      expect('unpackFn' in out).toBe(false);
+    });
+
+    it('returns {} for non-objects', () => {
+      expect(pickSerializableConfig(undefined)).toEqual({});
+      expect(pickSerializableConfig('nope')).toEqual({});
+    });
+  });
+});
+
+describe('EmbeddedReplayerClient', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  // iframe stand-in whose contentWindow is the real window, so the client's
+  // `event.source === iframe.contentWindow` check passes for our synthetic events.
+  function makeClient() {
+    const iframe = { contentWindow: window } as unknown as HTMLIFrameElement;
+    const posted: unknown[] = [];
+    vi.spyOn(window, 'postMessage').mockImplementation((msg: unknown) => {
+      posted.push(msg);
+    });
+    const client = new EmbeddedReplayerClient(iframe, { hostOrigin: '*' });
+    return { client, posted };
+  }
+
+  function deliver(message: HostMessage, source: unknown = window) {
+    const event = new MessageEvent('message', { data: wrap(message) });
+    Object.defineProperty(event, 'source', { value: source });
+    window.dispatchEvent(event);
+  }
+
+  it('posts namespaced command envelopes', () => {
+    const { client, posted } = makeClient();
+    client.play(1234);
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      channel: RRWEB_EMBEDDED_CHANNEL,
+      version: RRWEB_EMBEDDED_PROTOCOL_VERSION,
+      message: { type: 'play', timeOffset: 1234 },
+    });
+  });
+
+  it('resolves whenReady on the ready handshake', async () => {
+    const { client } = makeClient();
+    let resolved = false;
+    const ready = client.whenReady().then(() => (resolved = true));
+    expect(resolved).toBe(false);
+    deliver({ type: 'ready' });
+    await ready;
+    expect(resolved).toBe(true);
+  });
+
+  it('forwards replayer events and time updates to on() listeners', () => {
+    const { client } = makeClient();
+    const onResize = vi.fn();
+    const onTime = vi.fn();
+    client.on('resize', onResize);
+    client.on('time', onTime);
+
+    deliver({
+      type: 'replayer-event',
+      event: 'resize',
+      payload: { width: 800, height: 600 },
+    });
+    deliver({ type: 'time', currentTime: 4200 });
+
+    expect(onResize).toHaveBeenCalledWith({ width: 800, height: 600 });
+    expect(onTime).toHaveBeenCalledWith(4200);
+    expect(client.getCurrentTime()).toBe(4200);
+  });
+
+  it('resolves RPC responses by id', async () => {
+    const { client } = makeClient();
+    const p = client.getActivityIntervals();
+    deliver({ type: 'response', id: 1, ok: true, data: [{ start: 0 }] });
+    await expect(p).resolves.toEqual([{ start: 0 }]);
+  });
+
+  it('ignores messages from an untrusted source', () => {
+    const { client } = makeClient();
+    const onTime = vi.fn();
+    client.on('time', onTime);
+    // A message whose source is NOT the iframe's contentWindow must be ignored.
+    deliver({ type: 'time', currentTime: 999 }, { fake: true });
+    expect(onTime).not.toHaveBeenCalled();
+    expect(client.getCurrentTime()).toBe(0);
+  });
+});

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -117,6 +117,7 @@ describe('EmbeddedReplayerClient', () => {
 
   it('posts namespaced command envelopes', () => {
     const { client, posted } = makeClient();
+    deliver({ type: 'ready' }); // handshake first, so commands post instead of queueing
     client.play(1234);
     expect(posted).toHaveLength(2); // [0] is the construction ping
     expect(posted[1]).toMatchObject({
@@ -126,8 +127,22 @@ describe('EmbeddedReplayerClient', () => {
     });
   });
 
+  it('buffers commands issued before the handshake and flushes them on ready', () => {
+    const { client, posted } = makeClient();
+    // Before `ready`, a command is held back — only the construction ping posted.
+    client.play(1234);
+    expect(posted).toHaveLength(1);
+    // The handshake flushes the queue, in order.
+    deliver({ type: 'ready' });
+    expect(posted).toHaveLength(2);
+    expect(posted[1]).toMatchObject({
+      message: { type: 'play', timeOffset: 1234 },
+    });
+  });
+
   it('sends layout intent, not styles, and defaults the anchor host-side', () => {
     const { client, posted } = makeClient();
+    deliver({ type: 'ready' }); // handshake first, so commands post instead of queueing
     client.setLayout(0.5, 'top');
     expect(posted[1]).toMatchObject({
       message: { type: 'setLayout', scale: 0.5, anchor: 'top' },

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -20,7 +20,11 @@ describe('embedded replay protocol', () => {
       expect(isEnvelope(null)).toBe(false);
       expect(isEnvelope({})).toBe(false);
       expect(
-        isEnvelope({ channel: 'other', version: 1, message: { type: 'ready' } }),
+        isEnvelope({
+          channel: 'other',
+          version: 1,
+          message: { type: 'ready' },
+        }),
       ).toBe(false);
       expect(
         isEnvelope({

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -138,11 +138,25 @@ describe('EmbeddedReplayerClient', () => {
     expect(client.getCurrentTime()).toBe(4200);
   });
 
-  it('resolves RPC responses by id', async () => {
+  it('caches metadata and activity intervals from the initialized message', () => {
     const { client } = makeClient();
-    const p = client.getActivityIntervals();
-    deliver({ type: 'response', id: 1, ok: true, data: [{ start: 0 }] });
-    await expect(p).resolves.toEqual([{ start: 0 }]);
+    expect(client.getMetaData()).toBeNull();
+    expect(client.getActivityIntervals()).toEqual([]);
+
+    deliver({
+      type: 'initialized',
+      metadata: { startTime: 0, endTime: 5000, totalTime: 5000 },
+      activityIntervals: [
+        { startTime: 0, endTime: 1000, duration: 1000, active: true },
+      ],
+    });
+
+    expect(client.getMetaData()).toEqual({
+      startTime: 0,
+      endTime: 5000,
+      totalTime: 5000,
+    });
+    expect(client.getActivityIntervals()).toHaveLength(1);
   });
 
   it('ignores messages from an untrusted source', () => {

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -9,6 +9,7 @@ import {
   type HostMessage,
 } from '../../src/replay/embedded/protocol';
 import { EmbeddedReplayerClient } from '../../src/replay/embedded/client';
+import { EmbeddedReplayerHost } from '../../src/replay/embedded/host';
 
 describe('embedded replay protocol', () => {
   describe('isEnvelope', () => {
@@ -102,11 +103,23 @@ describe('EmbeddedReplayerClient', () => {
     window.dispatchEvent(event);
   }
 
+  it('probes the host with a ping on construction', () => {
+    const { posted } = makeClient();
+    // A client attached to an already-booted host missed the one-shot `ready`
+    // announcement; the construction-time ping makes the host re-announce.
+    expect(posted).toHaveLength(1);
+    expect(posted[0]).toMatchObject({
+      channel: RRWEB_EMBEDDED_CHANNEL,
+      version: RRWEB_EMBEDDED_PROTOCOL_VERSION,
+      message: { type: 'ping' },
+    });
+  });
+
   it('posts namespaced command envelopes', () => {
     const { client, posted } = makeClient();
     client.play(1234);
-    expect(posted).toHaveLength(1);
-    expect(posted[0]).toMatchObject({
+    expect(posted).toHaveLength(2); // [0] is the construction ping
+    expect(posted[1]).toMatchObject({
       channel: RRWEB_EMBEDDED_CHANNEL,
       version: RRWEB_EMBEDDED_PROTOCOL_VERSION,
       message: { type: 'play', timeOffset: 1234 },
@@ -171,5 +184,73 @@ describe('EmbeddedReplayerClient', () => {
     deliver({ type: 'time', currentTime: 999 }, { fake: true });
     expect(onTime).not.toHaveBeenCalled();
     expect(client.getCurrentTime()).toBe(0);
+  });
+});
+
+describe('EmbeddedReplayerHost', () => {
+  const PARENT_ORIGIN = 'https://parent.example';
+
+  // Stand-in for window.parent: captures what the host posts back.
+  function makeHost() {
+    const parentWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+    const host = new EmbeddedReplayerHost({
+      expectedParentOrigin: PARENT_ORIGIN,
+      parentWindow,
+    });
+    return {
+      host,
+      posted: parentWindow.postMessage as ReturnType<typeof vi.fn>,
+      parentWindow,
+    };
+  }
+
+  function deliverCommand(
+    message: unknown,
+    { origin = PARENT_ORIGIN, source }: { origin?: string; source: unknown },
+  ) {
+    const event = new MessageEvent('message', { data: wrap(message), origin });
+    Object.defineProperty(event, 'source', { value: source });
+    window.dispatchEvent(event);
+  }
+
+  it('announces ready on start and re-announces on ping', () => {
+    const { host, posted, parentWindow } = makeHost();
+    host.start();
+    expect(posted).toHaveBeenCalledTimes(1);
+    expect(posted.mock.calls[0][0]).toMatchObject({
+      message: { type: 'ready' },
+    });
+    expect(posted.mock.calls[0][1]).toBe(PARENT_ORIGIN);
+
+    // A late-attaching client probes with ping; the host must re-announce.
+    deliverCommand({ type: 'ping' }, { source: parentWindow });
+    expect(posted).toHaveBeenCalledTimes(2);
+    expect(posted.mock.calls[1][0]).toMatchObject({
+      message: { type: 'ready' },
+    });
+    host.stop();
+  });
+
+  it('ignores commands from the wrong origin', () => {
+    const { host, posted, parentWindow } = makeHost();
+    host.start();
+    posted.mockClear();
+    deliverCommand(
+      { type: 'ping' },
+      { origin: 'https://evil.example', source: parentWindow },
+    );
+    expect(posted).not.toHaveBeenCalled();
+    host.stop();
+  });
+
+  it('ignores commands whose source is not the parent window', () => {
+    const { host, posted } = makeHost();
+    host.start();
+    posted.mockClear();
+    deliverCommand({ type: 'ping' }, { source: { fake: true } });
+    expect(posted).not.toHaveBeenCalled();
+    host.stop();
   });
 });

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -60,7 +60,7 @@ export const startServer = (defaultPort = 3030) =>
 
       let pathname = path.join(__dirname, sanitizePath);
       if (/^\/rrweb.*\.c?js.*/.test(sanitizePath)) {
-        pathname = path.join(__dirname, `../dist/main`, sanitizePath);
+        pathname = path.join(__dirname, `../dist`, sanitizePath);
       }
 
       try {

--- a/packages/rrweb/test/utils.ts
+++ b/packages/rrweb/test/utils.ts
@@ -335,6 +335,17 @@ export function replaceLast(str: string, find: string, replace: string) {
   return str.substring(0, index) + replace + str.substring(index + find.length);
 }
 
+// For anchors like '<head>' that must target the document's real head: the
+// inlined rrweb bundle can contain the same text in a string literal (e.g.
+// buildHostDocument's HTML template), so the last occurrence is not safe.
+export function replaceFirst(str: string, find: string, replace: string) {
+  const index = str.indexOf(find);
+  if (index === -1) {
+    return str;
+  }
+  return str.substring(0, index) + replace + str.substring(index + find.length);
+}
+
 export async function assertDomSnapshot(page: puppeteer.Page) {
   const cdp = await page.target().createCDPSession();
   const { data } = await cdp.send('Page.captureSnapshot', {


### PR DESCRIPTION
## Why

Replaying a recorded session means running the `Replayer` over data that came from end-user browsers. Today that happens in the embedding application's own realm: the `Replayer` is constructed in the parent page and rebuilds the recorded DOM downward into a child iframe. So the entire replay path — every parser, deserializer, and DOM rebuild step — operates with the embedding origin's privileges.

This PR adds the capability to run replay somewhere else instead: inside a sandboxed iframe served from a **separate, cross-site origin**, driven from the parent over `postMessage`. An embedder that adopts it gets replay with no application cookies, no same-origin access to application APIs, and no reach into the embedding page — so the blast radius of any bug anywhere in the replay path is bounded by that origin rather than by the app's. The current published API can't express this because it assumes the `Replayer` lives in the parent realm.

Opt-in and purely additive. Existing in-parent `Replayer` usage is untouched, and embedders who don't opt in see no behavior change.

## What

- **`protocol.ts`** — typed, versioned, namespaced `postMessage` contract. Data-only: no functions or DOM nodes ever cross the boundary, and nothing from a message is `eval`'d or constructed by name. Both sides authenticate their peer — the host by `event.origin` against a declared parent origin, the client by `event.source` identity (which holds regardless of what origin the host document is served from). `pickSerializableConfig` allowlists the data-only `playerConfig` subset.
- **`host.ts`** — `EmbeddedReplayerHost` / `startEmbeddedReplayerHost` run **inside** the iframe: construct the `Replayer` in that realm, forward `ReplayerEvents` back, apply playback/config commands, and push current-time telemetry while playing.
- **`client.ts`** — `EmbeddedReplayerClient` mirrors the control / event / getter surface a viewer needs, over the bridge, with cached synchronous getters (`getMetaData`, `getActivityIntervals`, `getCurrentTime`, `getDimensions`).
- **Layout** — the wrapper the replay renders into is not reachable from the embedding page, so `setLayout(scale, anchor)` sends scaling *intent* (never a CSS class or style string, which would mean nothing in the host document) and the host translates it into transform/position. The host retains it across re-inits, since each `Replayer` builds a fresh wrapper. It also reports the rendered geometry back — the cross-origin stand-in for `wrapper.getBoundingClientRect()`.
- **`host-document.ts`** — `buildHostDocument` emits the iframe HTML shell, including a `<meta>` CSP that names only the host bundle in `script-src` and omits `unsafe-eval`, so the replay realm loads no other script and compiles no code from strings. Defense in depth on top of the origin isolation itself.

## Deployment shape (important)

The host iframe needs `sandbox="allow-scripts allow-same-origin"` **on a dedicated origin that is cross-site to the app**. `allow-same-origin` is required, and an `allow-scripts`-only (opaque-origin) deployment is not viable: nested browsing contexts inherit sandbox flags, so inside an opaque-origin document every child iframe lands in a fresh opaque origin of its own and its `contentDocument` is unreachable — and the `Replayer` rebuilds the recorded DOM into exactly such a child iframe. Isolation therefore comes from the host origin being cross-site to the app, not from origin opacity. Corollary: never serve the host document from the app's own origin.

That means adopting this requires a separate hostname (or equivalent), which also buys a real HTTP-header CSP; the host origin is a config value, so which origin is used is a deployment choice rather than a code change.

## Validation

- `tsc -noEmit` clean, `eslint` clean, prettier clean.
- 16 unit tests (`test/replay/embedded.test.ts`): protocol guards, config sanitization (drops functions/DOM/unknown keys), client command/event/getter round-trip, untrusted-source rejection, and host-side origin/source authentication.
- 5 end-to-end tests (`test/replay/embedded-e2e.test.ts`): boots a real host — and a real `Replayer` — in a sandboxed iframe served from a second origin and drives it with a real client over two live servers. Covers the ready handshake, cross-origin rebuild plus metadata, current-time streaming across a re-init, resume-after-pause without rewinding, parent-driven scaling (asserted via the reported geometry, including that it survives a re-init), and a late-attaching client. Each of the lifecycle/layout fixes here has a case that fails without it.
- Also fixed here: two pre-existing shadow-DOM polyfill tests that broke once `buildHostDocument` put the literal text `<head>` into the bundle, because those tests splice polyfill `<script>` tags in with `replaceLast(html, '<head>', …)` after inlining the bundle — so the anchor matched inside the bundle source. They now anchor on the document's first `<head>`.
- Not covered here (follow-up): nested-iframe replay fidelity under isolation.
