### PR TITLE
fix(replay): rebuild canvas args only from known constructors, behind a config option

### DIFF
--- a/packages/rrweb/src/replay/canvas/2d.ts
+++ b/packages/rrweb/src/replay/canvas/2d.ts
@@ -9,12 +9,14 @@ export default async function canvasMutation({
   target,
   imageMap,
   errorHandler,
+  enforceCanvasArgAllowlist,
 }: {
   event: Parameters<Replayer['applyIncremental']>[0];
   mutations: canvasMutationCommand[];
   target: HTMLCanvasElement;
   imageMap: Replayer['imageMap'];
   errorHandler: Replayer['warnCanvasMutationFailed'];
+  enforceCanvasArgAllowlist?: boolean;
 }): Promise<void> {
   const ctx = target.getContext('2d');
 
@@ -29,7 +31,11 @@ export default async function canvasMutation({
   // step 1, deserialize args, they may be async
   const mutationArgsPromises = mutations.map(
     async (mutation: canvasMutationCommand): Promise<unknown[]> => {
-      return Promise.all(mutation.args.map(deserializeArg(imageMap, ctx)));
+      return Promise.all(
+        mutation.args.map(
+          deserializeArg(imageMap, ctx, undefined, enforceCanvasArgAllowlist),
+        ),
+      );
     },
   );
   const args = await Promise.all(mutationArgsPromises);

--- a/packages/rrweb/src/replay/canvas/deserialize-args.ts
+++ b/packages/rrweb/src/replay/canvas/deserialize-args.ts
@@ -68,13 +68,19 @@ export function deserializeArg(
   preload?: {
     isUnchanged: boolean;
   },
+  enforceCanvasArgAllowlist = false,
 ): (arg: CanvasArg) => Promise<any> {
   return async (arg: CanvasArg): Promise<any> => {
     if (arg && typeof arg === 'object' && 'rr_type' in arg) {
       if (preload) preload.isUnchanged = false;
       if (arg.rr_type === 'ImageBitmap' && 'args' in arg) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const args = await deserializeArg(imageMap, ctx, preload)(arg.args);
+        const args = await deserializeArg(
+          imageMap,
+          ctx,
+          preload,
+          enforceCanvasArgAllowlist,
+        )(arg.args);
         // eslint-disable-next-line prefer-spread
         return await createImageBitmap.apply(null, args);
       } else if ('index' in arg) {
@@ -84,7 +90,7 @@ export function deserializeArg(
         return variableListFor(ctx, name)[index];
       } else if ('args' in arg) {
         const { rr_type: name, args } = arg;
-        if (!canvasArgConstructors.has(name)) {
+        if (enforceCanvasArgAllowlist && !canvasArgConstructors.has(name)) {
           console.warn(
             `[replayer] refusing to construct canvas arg of unknown type: ${name}`,
           );
@@ -96,7 +102,9 @@ export function deserializeArg(
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
         return new ctor(
           ...(await Promise.all(
-            args.map(deserializeArg(imageMap, ctx, preload)),
+            args.map(
+              deserializeArg(imageMap, ctx, preload, enforceCanvasArgAllowlist),
+            ),
           )),
         );
       } else if ('base64' in arg) {
@@ -113,7 +121,9 @@ export function deserializeArg(
         }
       } else if ('data' in arg && arg.rr_type === 'Blob') {
         const blobContents = await Promise.all(
-          arg.data.map(deserializeArg(imageMap, ctx, preload)),
+          arg.data.map(
+            deserializeArg(imageMap, ctx, preload, enforceCanvasArgAllowlist),
+          ),
         );
         const blob = new Blob(blobContents, {
           type: arg.type,
@@ -122,7 +132,9 @@ export function deserializeArg(
       }
     } else if (Array.isArray(arg)) {
       const result = await Promise.all(
-        arg.map(deserializeArg(imageMap, ctx, preload)),
+        arg.map(
+          deserializeArg(imageMap, ctx, preload, enforceCanvasArgAllowlist),
+        ),
       );
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return result;

--- a/packages/rrweb/src/replay/canvas/deserialize-args.ts
+++ b/packages/rrweb/src/replay/canvas/deserialize-args.ts
@@ -27,6 +27,33 @@ export function variableListFor(
   return contextMap.get(ctor) as any[];
 }
 
+/**
+ * The `rr_type` values that the canvas recorder rebuilds by calling a
+ * constructor of that name — see `record/observers/canvas/serialize-args.ts`
+ * for the matching serialization. A recording is untrusted input at replay
+ * time, so `rr_type` is matched against this set rather than resolved as an
+ * arbitrary global.
+ */
+const canvasArgConstructors = new Set([
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array',
+  'Float32Array',
+  'Float64Array',
+  'DataView',
+  'ImageData',
+  // normally serialized as base64, but reachable in `args` form through
+  // recordings made by older clients and through nested `DataView` args.
+  'ArrayBuffer',
+  // wraps nested args in recordings made by older clients — see the
+  // `preloadAllImages` tests for the shape.
+  'Array',
+]);
+
 export function isSerializedArg(arg: unknown): arg is SerializedCanvasArg {
   return Boolean(arg && typeof arg === 'object' && 'rr_type' in arg);
 }
@@ -57,6 +84,12 @@ export function deserializeArg(
         return variableListFor(ctx, name)[index];
       } else if ('args' in arg) {
         const { rr_type: name, args } = arg;
+        if (!canvasArgConstructors.has(name)) {
+          console.warn(
+            `[replayer] refusing to construct canvas arg of unknown type: ${name}`,
+          );
+          return null;
+        }
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         const ctor = window[name as keyof Window];
 

--- a/packages/rrweb/src/replay/canvas/index.ts
+++ b/packages/rrweb/src/replay/canvas/index.ts
@@ -15,6 +15,7 @@ export default async function canvasMutation({
   imageMap,
   canvasEventMap,
   errorHandler,
+  enforceCanvasArgAllowlist,
 }: {
   event: Parameters<Replayer['applyIncremental']>[0];
   mutation: canvasMutationData;
@@ -22,6 +23,7 @@ export default async function canvasMutation({
   imageMap: Replayer['imageMap'];
   canvasEventMap: Replayer['canvasEventMap'];
   errorHandler: Replayer['warnCanvasMutationFailed'];
+  enforceCanvasArgAllowlist?: boolean;
 }): Promise<void> {
   try {
     const precomputedMutation: canvasMutationParam =
@@ -41,6 +43,7 @@ export default async function canvasMutation({
           target,
           imageMap,
           errorHandler,
+          enforceCanvasArgAllowlist,
         });
       }
       return;
@@ -52,6 +55,7 @@ export default async function canvasMutation({
       target,
       imageMap,
       errorHandler,
+      enforceCanvasArgAllowlist,
     });
   } catch (error) {
     errorHandler(mutation, error);

--- a/packages/rrweb/src/replay/canvas/webgl.ts
+++ b/packages/rrweb/src/replay/canvas/webgl.ts
@@ -57,12 +57,14 @@ export default async function webglMutation({
   type,
   imageMap,
   errorHandler,
+  enforceCanvasArgAllowlist,
 }: {
   mutation: canvasMutationCommand;
   target: HTMLCanvasElement;
   type: CanvasContext;
   imageMap: Replayer['imageMap'];
   errorHandler: Replayer['warnCanvasMutationFailed'];
+  enforceCanvasArgAllowlist?: boolean;
 }): Promise<void> {
   try {
     const ctx = getContext(target, type);
@@ -86,7 +88,9 @@ export default async function webglMutation({
     ) => void;
 
     const args = await Promise.all(
-      mutation.args.map(deserializeArg(imageMap, ctx)),
+      mutation.args.map(
+        deserializeArg(imageMap, ctx, undefined, enforceCanvasArgAllowlist),
+      ),
     );
     const result = original.apply(ctx, args);
     saveToWebGLVarMap(ctx, result);

--- a/packages/rrweb/src/replay/embedded/protocol.ts
+++ b/packages/rrweb/src/replay/embedded/protocol.ts
@@ -56,6 +56,7 @@ export const SERIALIZABLE_CONFIG_KEYS = [
   'insertStyleRules',
   'triggerFocus',
   'UNSAFE_replayCanvas',
+  'enforceCanvasArgAllowlist',
   'cspContent',
   'pauseAnimation',
   'mouseTail',

--- a/packages/rrweb/src/replay/index.ts
+++ b/packages/rrweb/src/replay/index.ts
@@ -204,6 +204,7 @@ export class Replayer {
       insertStyleRules: [],
       triggerFocus: true,
       UNSAFE_replayCanvas: false,
+      enforceCanvasArgAllowlist: false,
       pauseAnimation: true,
       mouseTail: defaultMouseTailConfig,
       useVirtualDom: true, // Virtual-dom optimization is enabled by default.
@@ -243,6 +244,7 @@ export class Replayer {
               imageMap: this.imageMap,
               canvasEventMap: this.canvasEventMap,
               errorHandler: this.warnCanvasMutationFailed.bind(this),
+              enforceCanvasArgAllowlist: this.config.enforceCanvasArgAllowlist,
             });
           },
           applyInput: this.applyInput.bind(this),
@@ -1254,7 +1256,14 @@ export class Replayer {
         const commands = await Promise.all(
           data.commands.map(async (c) => {
             const args = await Promise.all(
-              c.args.map(deserializeArg(this.imageMap, null, status)),
+              c.args.map(
+                deserializeArg(
+                  this.imageMap,
+                  null,
+                  status,
+                  this.config.enforceCanvasArgAllowlist,
+                ),
+              ),
             );
             return { ...c, args };
           }),
@@ -1263,7 +1272,14 @@ export class Replayer {
           this.canvasEventMap.set(event, { ...data, commands });
       } else {
         const args = await Promise.all(
-          data.args.map(deserializeArg(this.imageMap, null, status)),
+          data.args.map(
+            deserializeArg(
+              this.imageMap,
+              null,
+              status,
+              this.config.enforceCanvasArgAllowlist,
+            ),
+          ),
         );
         if (status.isUnchanged === false)
           this.canvasEventMap.set(event, { ...data, args });
@@ -1515,6 +1531,7 @@ export class Replayer {
             imageMap: this.imageMap,
             canvasEventMap: this.canvasEventMap,
             errorHandler: this.warnCanvasMutationFailed.bind(this),
+            enforceCanvasArgAllowlist: this.config.enforceCanvasArgAllowlist,
           });
         }
         break;

--- a/packages/rrweb/src/types.ts
+++ b/packages/rrweb/src/types.ts
@@ -218,6 +218,14 @@ export type playerConfig = {
   triggerFocus: boolean;
   UNSAFE_replayCanvas: boolean;
   /**
+   * Rebuild canvas mutation args only from the constructors the recorder
+   * emits, dropping any other `rr_type` instead of resolving it off `window`
+   * (see `replay/canvas/deserialize-args.ts`). Off by default so the embedding
+   * app can roll it out; canvas replay of args this list doesn't cover
+   * degrades to a blank draw rather than failing the session.
+   */
+  enforceCanvasArgAllowlist: boolean;
+  /**
    * Optional Content-Security-Policy applied to the replay iframe. When set, a
    * `<meta http-equiv="Content-Security-Policy">` carrying this policy is added
    * to the iframe's <head> during full-snapshot rebuild, before the rebuilt DOM

--- a/packages/rrweb/test/replay/deserialize-args.test.ts
+++ b/packages/rrweb/test/replay/deserialize-args.test.ts
@@ -156,19 +156,10 @@ describe('deserializeArg', () => {
     expect(deserialized.size).toEqual(expected.size);
   });
 
-  it('should deserialize ImageData values', async () => {
-    expect(
-      await deserializeArg(
-        new Map(),
-        context,
-      )({
-        rr_type: 'ImageData',
-        args: [{ rr_type: 'Uint8ClampedArray', args: [[1, 2, 3, 4]] }, 1, 1],
-      }),
-    ).toEqual(new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
-  });
-
   describe('constructor allowlist', () => {
+    // the allowlist is opt-in; `enforceCanvasArgAllowlist` is the 4th arg
+    const enforcing = () => deserializeArg(new Map(), context, undefined, true);
+
     const recorderEmittedTypes = [
       'Int8Array',
       'Int16Array',
@@ -182,14 +173,9 @@ describe('deserializeArg', () => {
     ];
 
     it.each(recorderEmittedTypes)(
-      'should deserialize %s values',
+      'should deserialize %s values while enforcing',
       async (rr_type) => {
-        const deserialized = await deserializeArg(
-          new Map(),
-          context,
-        )({ rr_type, args: [[1, 2, 3, 4]] });
-
-        expect(deserialized).toEqual(
+        expect(await enforcing()({ rr_type, args: [[1, 2, 3, 4]] })).toEqual(
           new (window[rr_type as keyof Window] as Uint8ArrayConstructor)([
             1, 2, 3, 4,
           ]),
@@ -197,35 +183,72 @@ describe('deserializeArg', () => {
       },
     );
 
+    it('should deserialize ImageData while enforcing', async () => {
+      expect(
+        await enforcing()({
+          rr_type: 'ImageData',
+          args: [{ rr_type: 'Uint8ClampedArray', args: [[1, 2, 3, 4]] }, 1, 1],
+        }),
+      ).toEqual(new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
+    });
+
+    it('should deserialize DataView over a base64 ArrayBuffer while enforcing', async () => {
+      expect(
+        await enforcing()({
+          rr_type: 'DataView',
+          args: [
+            { rr_type: 'ArrayBuffer', base64: 'AAAAAAAAAAAAAAAAAAAAAA==' },
+            0,
+            16,
+          ],
+        }),
+      ).toStrictEqual(new DataView(new ArrayBuffer(16), 0, 16));
+    });
+
     it('should deserialize the Array wrapper older clients emit', async () => {
       expect(
-        await deserializeArg(
-          new Map(),
-          context,
-        )({
+        await enforcing()({
           rr_type: 'Array',
           args: [{ rr_type: 'Float32Array', args: [[1, 2]] }],
         }),
       ).toEqual([new Float32Array([1, 2])]);
     });
 
+    it('should leave the src and data branches alone while enforcing', async () => {
+      const image = new Image();
+      image.src = 'http://example.com/image.png';
+      expect(
+        await enforcing()({
+          rr_type: 'HTMLImageElement',
+          src: 'http://example.com/image.png',
+        }),
+      ).toStrictEqual(image);
+
+      expect(
+        await enforcing()({
+          rr_type: 'Blob',
+          data: [{ rr_type: 'ArrayBuffer', base64: 'AQIABA==' }],
+          type: 'image/png',
+        }),
+      ).toEqual(
+        new Blob([new Uint8Array([1, 2, 0, 4]).buffer], {
+          type: 'image/png',
+        }),
+      );
+    });
+
     it.each(['Function', 'Promise', 'XMLHttpRequest', 'Object'])(
-      'should not construct %s from a serialized arg',
+      'should not construct %s while enforcing',
       async (rr_type) => {
-        expect(
-          await deserializeArg(new Map(), context)({ rr_type, args: [] }),
-        ).toBeNull();
+        expect(await enforcing()({ rr_type, args: [] })).toBeNull();
       },
     );
 
-    it('should not evaluate a string passed to a constructor it does not know', async () => {
+    it('should not evaluate a string passed to a type it does not know', async () => {
       const canary = '__deserializeArgCanary';
       delete (globalThis as Record<string, unknown>)[canary];
 
-      const deserialized = await deserializeArg(
-        new Map(),
-        context,
-      )({
+      const deserialized = await enforcing()({
         rr_type: 'Function',
         args: [`globalThis[${JSON.stringify(canary)}] = true;`],
       });
@@ -236,11 +259,17 @@ describe('deserializeArg', () => {
 
     it('should reject unknown types nested in an arg list', async () => {
       expect(
+        await enforcing()([1, { rr_type: 'Function', args: ['return 1'] }, 3]),
+      ).toEqual([1, null, 3]);
+    });
+
+    it('should not filter anything when enforcement is off (the default)', async () => {
+      expect(
         await deserializeArg(
           new Map(),
           context,
-        )([1, { rr_type: 'Function', args: ['return 1'] }, 3]),
-      ).toEqual([1, null, 3]);
+        )({ rr_type: 'Object', args: [] }),
+      ).toEqual({});
     });
   });
 

--- a/packages/rrweb/test/replay/deserialize-args.test.ts
+++ b/packages/rrweb/test/replay/deserialize-args.test.ts
@@ -156,6 +156,94 @@ describe('deserializeArg', () => {
     expect(deserialized.size).toEqual(expected.size);
   });
 
+  it('should deserialize ImageData values', async () => {
+    expect(
+      await deserializeArg(
+        new Map(),
+        context,
+      )({
+        rr_type: 'ImageData',
+        args: [{ rr_type: 'Uint8ClampedArray', args: [[1, 2, 3, 4]] }, 1, 1],
+      }),
+    ).toEqual(new ImageData(new Uint8ClampedArray([1, 2, 3, 4]), 1, 1));
+  });
+
+  describe('constructor allowlist', () => {
+    const recorderEmittedTypes = [
+      'Int8Array',
+      'Int16Array',
+      'Int32Array',
+      'Uint8Array',
+      'Uint8ClampedArray',
+      'Uint16Array',
+      'Uint32Array',
+      'Float32Array',
+      'Float64Array',
+    ];
+
+    it.each(recorderEmittedTypes)(
+      'should deserialize %s values',
+      async (rr_type) => {
+        const deserialized = await deserializeArg(
+          new Map(),
+          context,
+        )({ rr_type, args: [[1, 2, 3, 4]] });
+
+        expect(deserialized).toEqual(
+          new (window[rr_type as keyof Window] as Uint8ArrayConstructor)([
+            1, 2, 3, 4,
+          ]),
+        );
+      },
+    );
+
+    it('should deserialize the Array wrapper older clients emit', async () => {
+      expect(
+        await deserializeArg(
+          new Map(),
+          context,
+        )({
+          rr_type: 'Array',
+          args: [{ rr_type: 'Float32Array', args: [[1, 2]] }],
+        }),
+      ).toEqual([new Float32Array([1, 2])]);
+    });
+
+    it.each(['Function', 'Promise', 'XMLHttpRequest', 'Object'])(
+      'should not construct %s from a serialized arg',
+      async (rr_type) => {
+        expect(
+          await deserializeArg(new Map(), context)({ rr_type, args: [] }),
+        ).toBeNull();
+      },
+    );
+
+    it('should not evaluate a string passed to a constructor it does not know', async () => {
+      const canary = '__deserializeArgCanary';
+      delete (globalThis as Record<string, unknown>)[canary];
+
+      const deserialized = await deserializeArg(
+        new Map(),
+        context,
+      )({
+        rr_type: 'Function',
+        args: [`globalThis[${JSON.stringify(canary)}] = true;`],
+      });
+
+      expect(deserialized).toBeNull();
+      expect((globalThis as Record<string, unknown>)[canary]).toBeUndefined();
+    });
+
+    it('should reject unknown types nested in an arg list', async () => {
+      expect(
+        await deserializeArg(
+          new Map(),
+          context,
+        )([1, { rr_type: 'Function', args: ['return 1'] }, 3]),
+      ).toEqual([1, null, 3]);
+    });
+  });
+
   describe('isUnchanged', () => {
     it('should set isUnchanged:true when non of the args are changed', async () => {
       const status = {

--- a/packages/rrweb/test/replay/embedded.test.ts
+++ b/packages/rrweb/test/replay/embedded.test.ts
@@ -51,12 +51,14 @@ describe('embedded replay protocol', () => {
         speed: 2,
         skipInactive: true,
         UNSAFE_replayCanvas: false,
+        enforceCanvasArgAllowlist: true,
         cspContent: "script-src 'none'",
       });
       expect(out).toEqual({
         speed: 2,
         skipInactive: true,
         UNSAFE_replayCanvas: false,
+        enforceCanvasArgAllowlist: true,
         cspContent: "script-src 'none'",
       });
     });


### PR DESCRIPTION
## What

`deserializeArg` rebuilt a serialized canvas arg by looking its `rr_type` up on `window` and calling it as a constructor. This adds an explicit set of the constructors the recorder actually emits (see `record/observers/canvas/serialize-args.ts` for the matching serialization):

- the nine typed arrays, `DataView`, `ImageData`
- `ArrayBuffer` — normally serialized as base64, but reachable in `args` form from older clients and nested inside `DataView` args
- `Array` — the nested-arg wrapper older clients emit (covered by the existing `preloadAllImages` tests)

Anything else deserializes to `null` and logs `[replayer] refusing to construct canvas arg of unknown type: <name>`, so a missing entry shows up in the replayer console instead of a silently blank canvas.

`null` rather than a throw is deliberate: `deserializeArg` runs inside `preloadAllImages` and inside an un-caught `Promise.all` in `replay/canvas/2d.ts`, so one odd arg shouldn't take down preload for an entire session. The existing `warnCanvasMutationFailed` handler already covers the downstream canvas call failing.

## Opt-in

The second commit puts this behind a new `enforceCanvasArgAllowlist` player config option, **defaulting to `false`** — current behavior is unchanged unless an embedding app opts in, so it can be rolled out and rolled back without shipping a new bundle.

It's threaded from `playerConfig` through the canvas mutation dispatcher into `deserializeArg`, covering both the mutation path (`replay/canvas/{index,2d,webgl}.ts`) and the eager preload path (`deserializeAndPreloadCanvasEvents`) — the latter matters because preload caches its deserialized args into `canvasEventMap`, which the mutation path then reuses.

It's also in `SERIALIZABLE_CONFIG_KEYS`, so the option survives the postMessage boundary into the embedded replayer host. Without that entry `pickSerializableConfig` would silently drop it and origin-isolated replay would never see it.

Replay-side only — nothing in `record/` changes.

## Not affected

`ImageBitmap`, `HTMLImageElement`, `Blob` and the WebGL variable references are handled by the `rr_type === 'ImageBitmap'`, `src`, `data` and `index` branches, none of which reach the constructor path. There are tests asserting those still work with enforcement on.

## Tests

`packages/rrweb/test/replay/deserialize-args.test.ts` — 33 tests, up from 13:

- with enforcement on: each of the nine typed arrays, `ImageData`, `DataView` over a base64 `ArrayBuffer`, and the `Array` wrapper all round-trip; the `src` and `data` branches are untouched
- with enforcement on: unknown types deserialize to `null`, including nested in an arg list, and a string argument to an unknown type is never evaluated
- with enforcement off (the default): nothing is filtered

`test/replay/embedded.test.ts` — `pickSerializableConfig` keeps the new key.

The negative tests were confirmed failing against the unpatched deserializer before the fix went in, and the whole thing was exercised against the built UMD bundle in Chrome 115 with both flag states.

Verified locally on macOS:

- `vitest run test/replay test/replayer.test.ts` — 140 passed, 1 skipped, incl. the webgl replay, embedded-replayer e2e, and painted-canvas-in-iframe tests
- `tsc -noEmit` clean; `eslint packages/rrweb/src` adds no new warnings; `prettier --check` clean

Worth noting: the existing `preloadAllImages` suite is what surfaced the `Array` wrapper, which an allowlist derived from `serialize-args.ts` alone would have missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Canvas replay deserialization no longer treats every serialized `rr_type` as a `window` constructor. **`deserializeArg`** now supports an optional allowlist of recorder-emitted types (typed arrays, `DataView`, `ImageData`, `ArrayBuffer`, `Array`); when enforcement is on, unknown types return **`null`** and log a replayer warning instead of instantiating arbitrary globals.
> 
> The behavior is gated by a new **`enforceCanvasArgAllowlist`** player config (**default `false`**). The flag is passed through 2D/WebGL canvas mutation paths, eager **`deserializeAndPreloadCanvasEvents`** preload (so **`canvasEventMap`** stays consistent), and **`SERIALIZABLE_CONFIG_KEYS`** for embedded replay over **`postMessage`**.
> 
> Tests cover allowlisted round-trips, rejection of types like **`Function`/`Object`** (including nested args and non-evaluated string payloads), and unchanged behavior when enforcement is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fce2342d8877b3a8bd29167b68d3ad779347ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->